### PR TITLE
Correctly display timestamps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,5 @@ require File.expand_path('../config/application', __FILE__)
 require 'ci/reporter/rake/minitest' if Rails.env.test?
 
 ReleaseApp::Application.load_tasks
+
+task :default => [:test, :check_for_bad_time_handling]

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -1,6 +1,6 @@
 class DeploymentsController < ApplicationController
   def new
-    default_deploy_time = Time.now.strftime("%e/%m/%Y %H:%M")
+    default_deploy_time = Time.zone.now.strftime("%e/%m/%Y %H:%M")
     @deployment = Deployment.new(application_id: params[:application_id], environment: params[:environment], created_at: default_deploy_time)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module ReleaseApp
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/lib/tasks/check_for_bad_time_handling.rake
+++ b/lib/tasks/check_for_bad_time_handling.rake
@@ -1,0 +1,25 @@
+task :check_for_bad_time_handling do
+  directories = Dir.glob(File.join(Rails.root, '**', '*.rb'))
+  matching_files = directories.select do |filename|
+    match = false
+    File.open(filename) do |file|
+      match = file.grep(%r{Time\.(now|utc|parse)}).any?
+    end
+    match
+  end
+  if matching_files.any?
+    raise <<-MSG
+
+Avoid issues with daylight-savings time by always building instances of
+TimeWithZone and not Time. Use methods like:
+    Time.zone.now, Time.zone.parse, n.days.ago, m.hours.from_now, etc
+
+in preference to methods like:
+    Time.now, Time.utc, Time.parse, etc
+
+Files that contain bad Time handling:
+  #{matching_files.join("\n  ")}
+
+MSG
+  end
+end

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :release do
     summary "release summary"
     notes "release notes"
-    deploy_at { Time.now }
+    deploy_at { Time.zone.now }
     user
 
     after(:build) do |release|

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -15,7 +15,7 @@ class DeploymentsControllerTest < ActionController::TestCase
         refute_nil deployment
         assert_equal "release_123", deployment.version
         assert_equal "staging", deployment.environment
-        assert_equal "2013-01-18 11:57:00 UTC", deployment.created_at.to_s
+        assert_equal "2013-01-18 11:57:00 +0000", deployment.created_at.to_s
       end
 
       should "redisplay the form on error" do

--- a/test/functional/releases_controller_test.rb
+++ b/test/functional/releases_controller_test.rb
@@ -31,13 +31,13 @@ class ReleasesControllerTest < ActionController::TestCase
 
     should "create a release" do
       assert_difference "Release.count", 1 do
-        post :create, release: { summary: "My First App", deploy_at: Time.now, tasks_attributes: { "0" => { description: "Description", version: "123", application_id: @app.id } } }
+        post :create, release: { summary: "My First App", deploy_at: Time.zone.now, tasks_attributes: { "0" => { description: "Description", version: "123", application_id: @app.id } } }
       end
     end
 
     should "create the release as the signed in user" do
       assert_difference "Release.count", 1 do
-        post :create, release: { summary: "My First App", deploy_at: Time.now, tasks_attributes: { "0" => { description: "Description", version: "123", application_id: @app.id } } }
+        post :create, release: { summary: "My First App", deploy_at: Time.zone.now, tasks_attributes: { "0" => { description: "Description", version: "123", application_id: @app.id } } }
       end
 
       release = Release.first

--- a/test/unit/release_test.rb
+++ b/test/unit/release_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class ReleaseTest < ActiveSupport::TestCase
   context "loading releases" do
     should "load previous releases, upcoming releases, and releases for today" do
-      release_yesterday = FactoryGirl.create(:release, deploy_at: Time.parse('24-12-2012 13:30'), notes: "Yesterday")
-      release_today = FactoryGirl.create(:release, deploy_at: Time.parse('25-12-2012 14:00'), notes: "Right now")
-      release_tomorrow = FactoryGirl.create(:release, deploy_at: Time.parse('26-12-2012 13:30'), notes: "Tomorrow")
+      release_yesterday = FactoryGirl.create(:release, deploy_at: Time.zone.parse('24-12-2012 13:30'), notes: "Yesterday")
+      release_today = FactoryGirl.create(:release, deploy_at: Time.zone.parse('25-12-2012 14:00'), notes: "Right now")
+      release_tomorrow = FactoryGirl.create(:release, deploy_at: Time.zone.parse('26-12-2012 13:30'), notes: "Tomorrow")
 
       Timecop.freeze(Date.parse('25 December 2012')) do
         assert_equal 1, Release.previous_releases.count
@@ -27,7 +27,7 @@ class ReleaseTest < ActiveSupport::TestCase
       @atts = {
         summary: "Major new feature",
         notes: "A few notes about this release",
-        deploy_at: Time.parse("25-12-2012 13:00"),
+        deploy_at: Time.zone.parse("25-12-2012 13:00"),
         tasks_attributes: {
           "0" => { description: "Deploy new smart answer", version: "123", application_id: @application_one.id },
           "1" => { description: "Redirect old quick answer", version: "101", application_id: @application_two.id }


### PR DESCRIPTION
Correctly receive and display timestamps in the user's timezone (GMT or BST, not UTC).
