### PR TITLE
Set mailer delivery method to ses

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,7 @@ ReleaseApp::Application.configure do
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :ses
 
   # Enable threaded mode
   # config.threadsafe!


### PR DESCRIPTION
This is necessary for exception_notifier to work

See alphagov-deployment#235 for corresponding config.
