### PR TITLE
Improve performance of applications index.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
     link_to(git_ref, "#{app.repo_url}/tree/#{git_ref}", target: "_blank")
   end
 
-  def github_compare_to_master(deploy)
-    "#{deploy.application.repo_url}/compare/#{deploy.version}...master"
+  def github_compare_to_master(application, deploy)
+    "#{application.repo_url}/compare/#{deploy.version}...master"
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -16,8 +16,9 @@ class Application < ActiveRecord::Base
   default_scope order("name ASC")
 
   def latest_deploy_to_each_environment
+    return @latest_deploy_to_each_environment unless @latest_deploy_to_each_environment.nil?
     environments = deployments.select('DISTINCT environment').map(&:environment)
-    environments.each_with_object({}) do |environment, hash|
+    @latest_deploy_to_each_environment = environments.each_with_object({}) do |environment, hash|
       hash[environment] = deployments.last_deploy_to(environment)
     end
   end
@@ -27,11 +28,12 @@ class Application < ActiveRecord::Base
   end
 
   def staging_and_production_in_sync?
+    return @staging_and_production_in_sync unless @staging_and_production_in_sync.nil?
     staging = latest_deploy_to_each_environment["staging"]
     production = latest_deploy_to_each_environment["production"]
     staging_version = staging.nil? ? nil : staging.version
     production_version = production.nil? ? nil : production.version
-    staging_version == production_version
+    @staging_and_production_in_sync = (staging_version == production_version)
   end
 
   def shortname

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -18,7 +18,7 @@ class Deployment < ActiveRecord::Base
 
   def previous_deployment
     @previous_deployment ||= Deployment
-      .where(application_id: self.application.id, environment: self.environment)
+      .where(application_id: self.application_id, environment: self.environment)
       .order("created_at DESC")
       .offset(1)
       .first

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -19,7 +19,7 @@
           <%= application.staging_and_production_in_sync? ? "Yes" : "No" %>
         </td>
         <% @environments.each do |environment| %>
-          <% latest_deploy = application.deployments.last_deploy_to(environment) %>
+          <% latest_deploy = application.latest_deploy_to_each_environment[environment] %>
           <td class="<%= latest_deploy.try(:recent?) ? "deployed-recently" : "" %>" title="<%= latest_deploy.try(:created_at) || '' %>">
             <% if latest_deploy %>
               <%= github_tag_link_to(application, latest_deploy.version) %>
@@ -27,7 +27,7 @@
                 at
                 <%= human_datetime(latest_deploy.created_at) %>
               </span>
-              <%= link_to(github_compare_to_master(latest_deploy), target: "_blank", class: "compare") do %>
+              <%= link_to(github_compare_to_master(application, latest_deploy), target: "_blank", class: "compare") do %>
                 <i class="icon-random" title="Compare to master"></i>
               <% end %>
             <% else %>


### PR DESCRIPTION
Some tweaks to avoid unnecessary db queries when building the index. This reduces the number of queries per index row from around 20 to 4.  Some of the 20 queries were hitting the query cache, but that still slows things down. On my dev VM, this improved the rendering time from around 1550 ms to around 600ms.

I'm sure there's still room for improvement, but this is a start.
