### PR TITLE
Moar index speedup.

### DIFF
--- a/db/migrate/20140224143455_add_index_to_deployments.rb
+++ b/db/migrate/20140224143455_add_index_to_deployments.rb
@@ -1,0 +1,5 @@
+class AddIndexToDeployments < ActiveRecord::Migration
+  def change
+    add_index :deployments, [:application_id, :environment, :created_at], :name => "index_deployments_on_application_id_etc"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140103105016) do
+ActiveRecord::Schema.define(:version => 20140224143455) do
 
   create_table "applications", :force => true do |t|
     t.string   "name"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(:version => 20140103105016) do
     t.datetime "created_at",     :null => false
     t.datetime "updated_at",     :null => false
   end
+
+  add_index "deployments", ["application_id", "environment", "created_at"], :name => "index_deployments_on_application_id_etc"
 
   create_table "releases", :force => true do |t|
     t.text     "notes"


### PR DESCRIPTION
Add a db index to the deployments table.  The index view results in lots of queries of the deployments table which currently doesn't have any indices.

Prior to the index:

```
mysql> explain SELECT `deployments`.* FROM `deployments` WHERE `deployments`.`application_id` = 7 AND `deployments`.`environment` = 'staging' ORDER BY created_at DESC LIMIT 1\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: deployments
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 16742
        Extra: Using where; Using filesort
1 row in set (0.00 sec)
```

With the index:

```
mysql> explain SELECT `deployments`.* FROM `deployments` WHERE `deployments`.`application_id` = 7 AND `deployments`.`environment` = 'staging' ORDER BY created_at DESC LIMIT 1\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: deployments
         type: ref
possible_keys: index_deployments_on_application_id_etc
          key: index_deployments_on_application_id_etc
      key_len: 263
          ref: const,const
         rows: 21
        Extra: Using where
1 row in set (0.01 sec)
```
