### PR TITLE
Provide a JSON view for the applications that have been deployed

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,4 +33,21 @@ module ApplicationHelper
   def github_compare_to_master(application, deploy)
     "#{application.repo_url}/compare/#{deploy.version}...master"
   end
+
+  def application_metadata(applications, environments)
+    applications.map do |application|
+      versions = environments.map { |env|
+        env_deploy = application.deployments.last_deploy_to(env)
+        {env => env_deploy.version} unless env_deploy.nil?
+      }.reject!(&:nil?)
+
+      {
+        name: application.name,
+        repo: application.repo,
+        domain: application.domain,
+        staging_and_production_in_sync: application.staging_and_production_in_sync?,
+        deployed_versions: versions,
+      }
+    end
+  end
 end

--- a/app/views/applications/index.json.erb
+++ b/app/views/applications/index.json.erb
@@ -1,0 +1,1 @@
+<%= raw(application_metadata(@applications, @environments).to_json) -%>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ApplicationsControllerTest < ActionController::TestCase
+  include ApplicationHelper
+
   setup do
     login_as_stub_user
   end
@@ -34,6 +36,15 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "provide a title attribute to sort environment columns by date" do
       get :index
       assert_select "table td[title=?]", @deploy1.created_at
+    end
+
+    should "produce a JSON formatted list of applications" do
+      get :index, format: :json
+
+      applications = [@app1, @app2]
+
+      assert_equal 200, @response.status
+      assert_equal application_metadata(applications, ["staging", "production"]).to_json, @response.body
     end
   end
 


### PR DESCRIPTION
Allow querying the applications index as JSON and provide not only the
metadata for the application but also the latest deploy for each
environment that we support.
