### PR TITLE
Show the author's name on each commit

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,3 +15,8 @@ h1 {
   line-height: 46px;
   margin: 22px 0;
 }
+
+.author {
+  color: #999; /* To match the '.muted' rule */
+  padding-left: 1em;
+}

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -55,9 +55,11 @@
           <% end %>
           <td>
             <%= commit[:commit][:message].split(/\n/)[0] %>
-            <span class="muted">
-              <%= commit[:login] %>
+            <% if commit[:commit][:author] %>
+            <span class="author">
+              <%= commit[:commit][:author][:name] %>
             </span>
+            <% end %>
             <small>
             <%= link_to commit[:sha], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank", class: "pull-right" %>
             </small>


### PR DESCRIPTION
There was already code to display this, but it was either buggy or relied on an outdated API response format from GitHub.

There's now a smidgen of padding to the names to separate them from the commit messages themselves.

![Commit log with author names](https://cloud.githubusercontent.com/assets/32775/3384992/3df2bb3c-fc64-11e3-9e2f-8e223b0b5d1f.png)
