### PR TITLE
Make deployments in the last week easier to understand

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,8 @@ module ApplicationHelper
         date.strftime("%-l:%M%P today")
       elsif yesterday.cover?(date)
         date.strftime("%-l:%M%P yesterday")
+      elsif this_week.cover?(date)
+        date.strftime("%-l:%M%P on %A")
       elsif (11.months.ago < date)
         date.strftime("%-l:%M%P on %-e %b")
       else
@@ -40,5 +42,9 @@ private
 
   def yesterday
     (Time.zone.now - 1.day).all_day
+  end
+
+  def this_week
+    Time.zone.now.all_week
   end
 end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -102,6 +102,20 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_equal "10:02am yesterday", human_datetime(deploy_time)
     end
 
+    should "use the day of the week for the current week" do
+      Timecop.freeze(Time.zone.parse("2014-07-04 12:44")) do  # Friday
+        deploy_time = Time.zone.parse("2014-06-30 10:02")
+        assert_equal "10:02am on Monday", human_datetime(deploy_time)
+      end
+    end
+
+    should "display the date for last Sunday" do
+      Timecop.freeze(Time.zone.parse("2014-07-04 12:44")) do  # Friday
+        deploy_time = Time.zone.parse("2014-06-29 10:02")
+        assert_equal "10:02am on 29 Jun", human_datetime(deploy_time)
+      end
+    end
+
     should "show a year if the date is old" do
       assert_equal "2pm on 3 Jul 2010",
                    human_datetime(Time.zone.now.change(year: 2010, month: 7, day: 3, hour: 14))


### PR DESCRIPTION
We already present today’s deployments as “today”: let’s add “yesterday” and “on Monday” for recent deployments to avoid having to go and look in a calendar to find out what today is.

![screen shot 2014-08-14 at 15 26 32](https://cloud.githubusercontent.com/assets/32775/3921220/34e13820-23bf-11e4-8362-c980250a0af2.png)
