### PR TITLE
Name API applications correctly

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,15 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Add new inflection rules using the following format
-# (all these examples are active by default):
-# ActiveSupport::Inflector.inflections do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
-#
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym "API"
+end

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -119,6 +119,12 @@ class DeploymentsControllerTest < ActionController::TestCase
           assert_equal "New App", app.name
         end
 
+        should "inflect API correctly" do
+          post :create, { repo: "org/devops_api", deployment: { version: "release_1", environment: "staging" } }
+          app = Application.last
+          assert_equal "Devops API", app.name
+        end
+
         should "generate a friendly name from a name with a dash in it" do
           post :create, { repo: "org/new-app", deployment: { version: "release_1", environment: "staging" } }
           app = Application.last


### PR DESCRIPTION
When we create a new app and deploy it for the first time, the release app will have a stab at reconstructing the app's name from the address of its repository. Unfortunately, Rails doesn't know that "API" is an acronym, rather than a normal word, so whenever we deploy new APIs we end up with applications called "Manuals Api" and "Finder Api" and other such incorrectitude, until someone excessively pedantic goes in and corrects the capitalisation manually.
