### PR TITLE
Candidate deploy view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,22 @@ h1 {
 .commit-hash {
   font-family: monospace;
 }
+
+.deployment {
+  margin: 0 0 10px 0;
+
+  .env {
+    min-width: 8em;
+  }
+
+  time {
+    // to match `.label`
+    font-size: 75%;
+  }
+
+  &.production {
+    .env {
+      background: $production-color
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,7 @@ h1 {
   @extend .text-muted;
   padding-left: 1em;
 }
+
+.commit-hash {
+  font-family: monospace;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@ h1 {
   padding-left: 1em;
 }
 
+table.commits td.hash,
 .commit-hash {
   font-family: monospace;
 }
@@ -42,5 +43,11 @@ h1 {
     .env {
       background: $production-color
     }
+  }
+}
+
+.release-tag  {
+  &.label a {
+    color: #fff;
   }
 }

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -52,4 +52,12 @@ class Application < ActiveRecord::Base
   def repo_url
     "https://#{domain}/#{repo}"
   end
+
+  def repo_compare_url(from, to)
+    "https://#{domain}/#{repo}/compare/#{from}...#{to}"
+  end
+
+  def repo_tag_url(tag)
+    "https://#{domain}/#{repo}/releases/tag/#{tag}"
+  end
 end

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -28,13 +28,21 @@
   <p class="lead"><%= @commits.length %> <%= 'commit'.pluralize(@commits.length) %></p>
 
   <% if @github_available %>
-  <table class="table table-striped table-bordered table-hover commits">
+  <table class="table table-striped table-bordered table-hover commits" data-module="filterable-table">
     <thead>
       <tr class="table-header">
-        <th>Hash</th>
-        <th>Commit</th>
-        <th>Author</th>
+        <th width="10%">Hash</th>
+        <th width="70%">Commit</th>
+        <th width="20%">Author</th>
       </tr>
+      <tr class="if-no-js-hide table-header-secondary">
+          <td colspan="3">
+            <form>
+              <label for="table-filter" class="rm">Filter commits</label>
+              <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter commits">
+            </form>
+          </td>
+        </tr>
     </thead>
     <tbody>
       <% @commits.each do |commit| %>
@@ -43,7 +51,7 @@
             <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank" %>
           </td>
           <td>
-              <p><%= commit[:commit][:message].split(/\n/)[0] %></p>
+              <%= commit[:commit][:message].split(/\n/)[0] %>
           </td>
           <td>
             <% if commit[:commit][:author] %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -10,7 +10,7 @@
 
 <main>
   <h2>Candidate Release <span class="label label-info"><%= @release_tag %></span></h2>
-  <p class="lead add-top-margin">Production was deployed to <span class="label label-danger"><%= @production_deploy.version %></span><%= time_ago_in_words(@production_deploy.created_at) %> ago</p>
+  <p class="lead add-top-margin">Production is <span class="label label-danger"><%= @production_deploy.version %></span> &mdash; deployed at <%= human_datetime(@production_deploy.created_at) %></p>
 
   <% unless @application.staging_and_production_in_sync? %>
   <div class="callout callout-danger">

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -1,0 +1,85 @@
+<% content_for :page_title, @application.name %>
+
+<div class="page-header">
+  <h1 class="remove-bottom-margin">
+    <span class="name">Deploy <%= @application.name %></span>
+    <span class="shortname">(<%= @application.shortname %>)</span>
+  </h1>
+  <%= link_to @application.repo_url, @application.repo_url, target: "_blank" %>
+</div>
+
+<main>
+  <h2>Candidate Release <span class="label label-info"><%= @release_tag %></span></h2>
+  <p class="lead add-top-margin">Production was deployed to <span class="label label-danger"><%= @production_deploy.version %></span><%= time_ago_in_words(@production_deploy.created_at) %> ago</p>
+
+  <% unless @application.staging_and_production_in_sync? %>
+  <div class="callout callout-danger">
+    <div class="callout-title">Production and Staging are not in sync</div>
+    <div class="callout-body">Proceed with caution and check the <a href="<%= @application.repo_compare_url('deployed-to-production', 'deployed-to-staging') %>">differences between production and staging</a></div>
+  </div>
+  <% end %>
+
+  <p class="pull-right">
+    <a class="btn btn-default" href="<%= @application.repo_compare_url(@production_deploy.version, @release_tag) %>">
+      <i class="glyphicon glyphicon-new-window add-right-margin"></i>Full Diff
+    </a>
+  </p>
+
+  <p class="lead"><%= @commits.length %> <%= 'commit'.pluralize(@commits.length) %></p>
+
+  <% if @github_available %>
+  <table class="table table-striped table-bordered table-hover commits">
+    <thead>
+      <tr class="table-header">
+        <th>Hash</th>
+        <th>Commit</th>
+        <th>Author</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @commits.each do |commit| %>
+        <tr>
+          <td class="hash">
+            <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank" %>
+          </td>
+          <td>
+              <p><%= commit[:commit][:message].split(/\n/)[0] %></p>
+          </td>
+          <td>
+            <% if commit[:commit][:author] %>
+            <img height="20" width="20" class="avatar" src="<%= commit[:author][:avatar_url] %>" alt="" />
+            <span class="name">
+              <%= commit[:commit][:author][:name] %>
+            </span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert alert-error">
+    Couldn't get data from GitHub:
+    <br>
+    <%= @github_error %>
+  </div>
+<% end %>
+  </table>
+
+  <h2>Deploy</h2>
+  <div class="row">
+    <div class="col-md-3">
+      <a href="https://www.flickr.com/photos/fatty/9158066939/"><img title="Obey the Badger of Deploy" src="https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg" alt="Obey the Badger of Deploy" width="229" height="320"></a>
+    </div>
+
+    <div class="col-md-9">
+        <h3>Test on Staging</h3>
+        <p>Make sure you're using the <code>govuk_select_organisation</code> script to test against the staging environment.</p>
+        <p><a class="btn btn-primary add-bottom-margin" href="https://deploy.staging.alphagov.co.uk/job/Staging_Deploy/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
+
+        <h3>Promote to Production</h3>
+        <p><a class="btn btn-danger" href="https://deploy.production.alphagov.co.uk/job/Production_Deploy/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
+    </div>
+  </div>
+
+</main>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -32,11 +32,12 @@
     <thead>
       <tr class="table-header">
         <th width="10%">Hash</th>
-        <th width="70%">Commit</th>
+        <th width="55%">Message</th>
         <th width="20%">Author</th>
+        <th width="15%">Date</th>
       </tr>
       <tr class="if-no-js-hide table-header-secondary">
-          <td colspan="3">
+          <td colspan="4">
             <form>
               <label for="table-filter" class="rm">Filter commits</label>
               <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter commits">
@@ -50,20 +51,29 @@
           <td class="hash">
             <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank" %>
           </td>
-          <td>
+          <td class="message">
               <% summary, body = commit[:commit][:message].split(/\n/, 2) %>
-              <p><strong><%= summary %></strong></p>
+              <p class="summary"><a href="<%= "#{@application.repo_url}/commit/#{commit[:sha]}" %>" target="_blank"><%= summary %></a></p>
               <% if body %>
-                <%= simple_format(body.strip) %>
+                <div class="body">
+                  <%= simple_format(body.strip) %>
+                </div>
               <% end %>
           </td>
-          <td>
+          <td class="">
             <% if commit[:commit][:author] %>
             <img height="20" width="20" class="avatar" src="<%= commit[:author][:avatar_url] %>" alt="" />
             <span class="name">
               <%= commit[:commit][:author][:name] %>
             </span>
             <% end %>
+          </td>
+          <td calss="date">
+          <% if commit[:commit][:author] %>
+            <% commit_date = commit[:commit][:author][:date] %>
+            <span class="date"><%= commit_date.to_date.to_s(:govuk_date) =%></span>
+            <span class="time"><%= commit_date.to_s(:govuk_time) =%></span>
+          <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -62,7 +62,7 @@
           </td>
           <td class="">
             <% if commit[:commit][:author] %>
-            <img height="20" width="20" class="avatar" src="<%= commit[:author][:avatar_url] %>" alt="" />
+            <img height="20" width="20" class="avatar" src="<%= commit[:commit][:author][:avatar_url] %>" alt="" />
             <span class="name">
               <%= commit[:commit][:author][:name] %>
             </span>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -21,6 +21,9 @@
 
   <p class="pull-right">
     <a class="btn btn-default" href="<%= @application.repo_compare_url(@production_deploy.version, @release_tag) %>">
+      <i class="glyphicon glyphicon-new-window add-right-margin"></i>Show full Commit
+    </a>
+    <a class="btn btn-default" href="<%= @application.repo_compare_url(@production_deploy.version, @release_tag) %>">
       <i class="glyphicon glyphicon-new-window add-right-margin"></i>Full Diff
     </a>
   </p>
@@ -53,16 +56,11 @@
           </td>
           <td class="message">
               <% summary, body = commit[:commit][:message].split(/\n/, 2) %>
-              <p class="summary"><a href="<%= "#{@application.repo_url}/commit/#{commit[:sha]}" %>" target="_blank"><%= summary %></a></p>
-              <% if body %>
-                <div class="body">
-                  <%= simple_format(body.strip) %>
-                </div>
-              <% end %>
+              <a href="<%= "#{@application.repo_url}/commit/#{commit[:sha]}" %>" target="_blank"><%= summary %></a>
           </td>
           <td class="">
             <% if commit[:commit][:author] %>
-            <img height="20" width="20" class="avatar" src="<%= commit[:commit][:author][:avatar_url] %>" alt="" />
+            <img height="20" width="20" class="avatar" src="<%= commit[:author][:avatar_url] %>" alt="" />
             <span class="name">
               <%= commit[:commit][:author][:name] %>
             </span>
@@ -71,7 +69,7 @@
           <td calss="date">
           <% if commit[:commit][:author] %>
             <% commit_date = commit[:commit][:author][:date] %>
-            <span class="date"><%= commit_date.to_date.to_s(:govuk_date) =%></span>
+            <span class="date"><%= commit_date.to_date.to_s(:short) =%></span>
             <span class="time"><%= commit_date.to_s(:govuk_time) =%></span>
           <% end %>
           </td>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -51,7 +51,11 @@
             <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank" %>
           </td>
           <td>
-              <%= commit[:commit][:message].split(/\n/)[0] %>
+              <% summary, body = commit[:commit][:message].split(/\n/, 2) %>
+              <p><strong><%= summary %></strong></p>
+              <% if body %>
+                <%= simple_format(body.strip) %>
+              <% end %>
           </td>
           <td>
             <% if commit[:commit][:author] %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -37,10 +37,11 @@
               <% tags.each do |tag| %>
                 <% if deployments = @latest_deploy_to_each_environment_by_version[tag[:name]] %>
                   <% deployments.each do |deployment| %>
-                    <%= deployment.environment %>
-                    at
-                    <%= human_datetime(deployment.created_at) %>
-                    <br>
+                  <p class="deployment <%= 'production' if deployment.environment == 'production' %>">
+                    <strong class="label label-default env"><%= deployment.environment.humanize %></strong>
+                    <span class="rm">at</span>
+                    <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %>
+                  </p>
                   <% end %>
                 <% end %>
               <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -62,7 +62,7 @@
             </span>
             <% end %>
             <small>
-            <%= link_to commit[:sha], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank", class: "pull-right" %>
+            <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank", class: "commit-hash pull-right" %>
             </small>
           </td>
         </tr>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -48,7 +48,7 @@
             </td>
             <td>
               <% tags.each do |tag| %>
-                <span class="label label-info"><%= tag[:name] %></span>
+                <span class="release-tag label label-info"><a href="<%= deploy_application_path(@application) %>?tag=<%= tag[:name] %>"><%= tag[:name] %></a></span>
               <% end %>
             </td>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ ReleaseApp::Application.routes.draw do
       put :update_notes
     end
 
+    member do
+      get :deploy
+    end
+
     resources :deployments
   end
 


### PR DESCRIPTION
Simplify deployment process by giving you one page with all
the links and information you should need to do a deploy.

- Navigate to the new view from the list of commits/tags for
  an application
- See where production is, what release and how old
- Preview what commits, and authors, this release will contain
  with a link to view the full file diff on github
- Deep link to the staging/production deploy jobs, prefilling
  the application and release tag
- Bonus tweaks to some app commit listing UI

Very much minimum viable improvement, it could and will get better.

![image](https://cloud.githubusercontent.com/assets/63201/5860379/eafe8564-a258-11e4-858a-0354b947fe13.png)

Picking a candidate release:
![image](https://cloud.githubusercontent.com/assets/63201/5860444/3e8a4aec-a259-11e4-8455-b415c8cbc087.png)
(This isn't very intuitive, but i've got plans to improve this view separately)
