### PR TITLE
Gracefully handle repos on GitHub Enterprise

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -13,11 +13,6 @@ class ApplicationsController < ApplicationController
   end
 
   def show
-    @tags_by_commit = github.tags(@application.repo).each_with_object({}) do |tag, hash|
-      sha = tag[:commit][:sha];
-      hash[sha] ||= [];
-      hash[sha] << tag
-    end
     # where version == git tag, which it isn't for licensify
     @latest_deploy_to_each_environment_by_version = {}
     @application.latest_deploy_to_each_environment.each do |_environment, deployment|
@@ -26,20 +21,32 @@ class ApplicationsController < ApplicationController
     end
 
     @production_deploy = @application.deployments.last_deploy_to "production"
-    if @production_deploy
-      comparison = github.compare(
-        @application.repo,
-        @production_deploy.version,
-        "master"
-      )
-      # The `compare` API shows commits in forward chronological order
-      @commits = comparison.commits.reverse + [comparison.base_commit]
-    else
-      # the `commits` API shows commits in reverse chronological order
-      @commits = github.commits(@application.repo)
-    end
 
-    @github_available = true
+    if @application.on_github_enterprise?
+      @github_available = false
+      @github_error = "Repos hosted on GitHub Enterprise are not supported because GitHub Enterprise isn't accessible from production servers."
+    else
+      @tags_by_commit = github.tags(@application.repo).each_with_object({}) do |tag, hash|
+        sha = tag[:commit][:sha];
+        hash[sha] ||= [];
+        hash[sha] << tag
+      end
+
+      if @production_deploy
+        comparison = github.compare(
+          @application.repo,
+          @production_deploy.version,
+          "master"
+        )
+        # The `compare` API shows commits in forward chronological order
+        @commits = comparison.commits.reverse + [comparison.base_commit]
+      else
+        # the `commits` API shows commits in reverse chronological order
+        @commits = github.commits(@application.repo)
+      end
+
+      @github_available = true
+    end
   rescue Octokit::NotFound => e
     @github_available = false
     @github_error = e

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -60,4 +60,8 @@ class Application < ActiveRecord::Base
   def repo_tag_url(tag)
     "https://#{domain}/#{repo}/releases/tag/#{tag}"
   end
+
+  def on_github_enterprise?
+    domain == "github.gds"
+  end
 end


### PR DESCRIPTION
Even if github.gds were accessible from the production servers, it uses a
certificate we've signed ourselves which isn't in the bundle installed on our
servers, so Octokit refuses to connect to it.