### PR TITLE
Correct the inflection of 'api' manually

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -51,7 +51,8 @@ class DeploymentsController < ApplicationController
     end
 
     def app_name
-      repo_path.split("/")[-1].gsub("-", " ").humanize.titlecase
+      repo_title = repo_path.split("/")[-1].gsub("-", " ").humanize.titlecase
+      repo_title.gsub(/\bApi\b/, "API")
     end
 
     def domain

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym "API"
-end


### PR DESCRIPTION
On the face of things, customising this in the global inflection config seems like a nice idea. However...

Another part of the app that relies on the inflection config is Rails’ routing algorithm; this includes routes loaded in from engines defined in other gems, like [`gds-sso`](https://github.com/alphagov/gds-sso), which defines a controller within the `Api` namespace for updating users’ permissions. When this app tries to load the controller based on the routes defined in `gds-sso`, it expects `API::UserController`, but finds `Api::UserController` instead.

There's probably a longer-term fix we could make to `gds-sso` to make sure it can cope with different inflection settings, but for now this fixes the problem without spelunking into the innards of the Rails source code.