### PR TITLE
Remove unnecessary shortnames for tariff apps

### DIFF
--- a/db/migrate/20150317171107_remove_unnecessary_shortnames.rb
+++ b/db/migrate/20150317171107_remove_unnecessary_shortnames.rb
@@ -1,0 +1,15 @@
+class RemoveUnnecessaryShortnames < ActiveRecord::Migration
+  class Application < ActiveRecord::Base; end
+
+  def up
+    app = Application.find_by(shortname: "tariff")
+    app.shortname = nil
+    app.save!
+    app = Application.find_by(shortname: "tariff-api")
+    app.shortname = nil
+    app.save!
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150205100957) do
+ActiveRecord::Schema.define(version: 20150317171107) do
 
   create_table "applications", force: :cascade do |t|
     t.string   "name",         limit: 255


### PR DESCRIPTION
The trade tariff apps are now consistently named on the deploy Jenkinses
and GitHub, so don't need the shortnames set (they are inferred automatically
like for most other applications).

This fixes the "Deploy to Staging" and "Deploy to Production" buttons for Trade
Tariff Frontend and Backend.

/cc @jamiecobbett this is a follow-up to the conversation we had yesterday