### PR TITLE
Add a list of recent deployments to each app

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -30,6 +30,10 @@ class Application < ActiveRecord::Base
     latest_deploy_to_each_environment.select { |env, deploy| environments.include?(env) }
   end
 
+  def interesting_deployments
+    deployments.recent.interesting
+  end
+
   def staging_and_production_in_sync?
     return @staging_and_production_in_sync unless @staging_and_production_in_sync.nil?
     staging = latest_deploy_to_each_environment["staging"]

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -8,6 +8,9 @@ class Deployment < ActiveRecord::Base
 
   scope :recent, lambda { order("created_at DESC").limit(25) }
 
+  # Ignore automatic deployment of the release branch to preview
+  scope :interesting, lambda { where.not(environment: 'preview', version: 'release') }
+
   def self.environments
     Deployment.select('DISTINCT environment').map(&:environment)
   end
@@ -28,6 +31,10 @@ class Deployment < ActiveRecord::Base
 
   def recent?
     created_at > 2.hours.ago
+  end
+
+  def production?
+    environment == 'production'
   end
 
   private

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -116,3 +116,22 @@
     <% end %>
   </tbody>
 </table>
+
+<% if @application.interesting_deployments.any? %>
+  <h2 class="add-bottom-margin">Deployments</h2>
+  <ol class="list-group">
+    <% @application.interesting_deployments.each do |deployment| %>
+      <li class="list-group-item">
+        <%= github_tag_link_to(@application, deployment.version) %>
+        deployed to
+        <% if deployment.production? %>
+          <span class="label label-danger"><%= deployment.environment %></span>
+        <% else %>
+          <span class="label label-default"><%= deployment.environment %></span>
+        <% end %>
+        at
+        <%= human_datetime(deployment.created_at) %>
+      </li>
+    <% end %>
+  </ol>
+<% end %>


### PR DESCRIPTION
This list can be useful when supporting apps and diagnosing problems, so we can see the history of what has been deployed and when.

For some apps ([Whitehall](https://github.com/alphagov/whitehall), for example), there will be several pull requests merged before anything gets deployed to a non-preview environment, so this filters out the automated deployments of the `release` branch to the preview environment.

A possible future feature is to spot when an app has been deployed to staging and then to production shortly afterwards, as this is the way we usually release code. However, hopefully this is still enough functionality to be useful.

![screen shot 2015-04-09 at 16 29 17](https://cloud.githubusercontent.com/assets/32775/7070247/a0702bec-ded5-11e4-9ca7-57fc67a58f12.png)
