### PR TITLE
Change PUT to PATCH for update_notes method

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ ReleaseApp::Application.routes.draw do
     end
 
     member do
-      put :update_notes
+      patch :update_notes
     end
 
     member do


### PR DESCRIPTION
Rails 4 changed the default HTTP verb from PUT to PATCH for updates, which broke the note updating functionality in this app.