### PR TITLE
List recent deployments as a table, for filtering

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -118,20 +118,37 @@
 </table>
 
 <% if @application.interesting_deployments.any? %>
-  <h2 class="add-bottom-margin">Deployments</h2>
-  <ol class="list-group">
+  <h2>Recent deployments</h2>
+  <table class="table table-striped table-bordered table-hover" data-module="filterable-table">
+    <thead>
+      <tr class='table-header'>
+        <th scope="col" class="headerSortDown">Date</th>
+        <th scope="col">Environment</th>
+        <th>Release</th>
+      </tr>
+      <tr class="if-no-js-hide table-header-secondary">
+        <td colspan="3">
+          <form>
+            <label for="deployments-filter" class="rm">Filter Deployments</label>
+            <input id="deployments-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter deployments">
+          </form>
+        </td>
+      </tr>
+    </thead>
+    <tbody>
     <% @application.interesting_deployments.each do |deployment| %>
-      <li class="list-group-item">
-        <%= github_tag_link_to(@application, deployment.version) %>
-        deployed to
-        <% if deployment.production? %>
-          <span class="label label-danger"><%= deployment.environment %></span>
-        <% else %>
-          <span class="label label-default"><%= deployment.environment %></span>
-        <% end %>
-        at
-        <%= human_datetime(deployment.created_at) %>
-      </li>
+      <tr>
+        <td><%= human_datetime(deployment.created_at) %></td>
+        <td>
+          <% if deployment.production? %>
+            <span class="label label-danger"><%= deployment.environment %></span>
+          <% else %>
+            <span class="label label-default"><%= deployment.environment %></span>
+          <% end %>
+        </td>
+        <td><%= github_tag_link_to(@application, deployment.version) %></td>
+      </tr>
     <% end %>
-  </ol>
+    </tbody>
+  </table>
 <% end %>


### PR DESCRIPTION
Using the table filter feature we get free filtering by env, release number
and even by rough date. This is useful for tracking graph/error change
back to a release around a particular time.

Longer term it would be nice to surface all historic releases, and
make the release links more useful, eg permalinks for a release by id, as
a release could be deployed many times, and exposing exactly what
was deployed at that time, based on the previous release.

| Before | After |
|---|---|
| ![release-app-before](https://cloud.githubusercontent.com/assets/63201/8570904/6efbe154-257b-11e5-99fd-99a69cc51012.png) | ![release-app-after](https://cloud.githubusercontent.com/assets/63201/8570903/6ef61472-257b-11e5-928f-08c15178504a.png) |
