### PR TITLE
Update deploy job URLs

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -96,7 +96,7 @@
         <p><a class="btn btn-primary add-bottom-margin" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
-        <p><a class="btn btn-danger" href="https://deploy.production.alphagov.co.uk/job/Production_Deploy/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
+        <p><a class="btn btn-danger" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
The host changed as part of the migration. The old ones are being redirected, but it's better to use the new one in the first place.

Also the name of the Production job changed, it's now consistent with the Staging job, which is good, but meant the deploy link wasn't working.