### PR TITLE
Open deploy links in a new tab by default

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -93,10 +93,10 @@
 
       <div class="col-md-9">
         <h3>Test on Staging</h3>
-        <p><a class="btn btn-primary add-bottom-margin" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
+        <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
-        <p><a class="btn btn-danger" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
+        <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
- A lot of the time I forget to CMD+click on the "deploy" buttons,
  leading to them opening in the same tab that the release app was,
  meaning that I have to go back many pages to get to the release app
  from the deploy console that I invariably end up at. This change makes the
  release app easier to refer back to, as it stays open.

I don't know what the policy is on links behaving like this, so comments are welcome.

(cc @fofr @dsingleton)