### PR TITLE
Show application status notes on the show and deploy pages

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -9,6 +9,12 @@
 </div>
 
 <main>
+  <% if @application.status_notes.present? %>
+    <div class="alert alert-warning" role="alert">
+      <p><%= @application.status_notes %></p>
+    </div>
+  <% end %>
+
   <h2>Candidate Release <span class="label label-info"><%= @release_tag %></span></h2>
   <p class="lead add-top-margin">Production is <span class="label label-danger"><%= @production_deploy.version %></span> &mdash; deployed at <%= human_datetime(@production_deploy.created_at) %></p>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -18,6 +18,11 @@
 </div>
 <% end %>
 
+<% if @application.status_notes.present? %>
+  <div class="alert alert-warning" role="alert">
+    <p><%= @application.status_notes %></p>
+  </div>
+<% end %>
 
 <h2 class="add-bottom-margin">Commit log</h2>
 <% if @github_available %>


### PR DESCRIPTION
Notes are currently only surfaced on the index page, so if an important
message like "don't deploy without talking to team_x" is entered, the
user doing a deploy may not notice it.  By putting the note in a warning
alert on the show and deploy pages it should be more obvious to the user
that they should take care.

This may act as a way of reducing the need for the badger to act as a
physical cork board for these sorts of notice.  Which is prone to notices
falling off.