### PR TITLE
Fix filtering by "interesting" deployments

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -6,8 +6,8 @@ class Deployment < ApplicationRecord
 
   scope :recent, lambda { order("created_at DESC").limit(25) }
 
-  # Ignore automatic deployment of the release branch to preview
-  scope :interesting, lambda { where.not(environment: 'preview', version: 'release') }
+  # Ignore automatic deployments
+  scope :interesting, lambda { where.not(environment: %w[preview integration], version: 'release') }
 
   def self.environments
     Deployment.select('DISTINCT environment').map(&:environment)

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -124,6 +124,7 @@
 
 <% if @application.interesting_deployments.any? %>
   <h2>Recent deployments</h2>
+  <p>Excludes automatic deployments to integration.</p>
   <table class="table table-striped table-bordered table-hover" data-module="filterable-table">
     <thead>
       <tr class='table-header'>


### PR DESCRIPTION
When we switched from "preview" to "integration" this scope wasn't updated. This causes the automatic deployments to show up on the application page.

## Before

![screen shot 2016-11-16 at 12 15 27](https://cloud.githubusercontent.com/assets/233676/20346872/6978980a-abf6-11e6-8a54-1b14898910b0.png)

## After

![screen shot 2016-11-16 at 12 11 56](https://cloud.githubusercontent.com/assets/233676/20346878/6defaeb4-abf6-11e6-9bd0-4fe9b07ae107.png)
