### PR TITLE
Don't filter deployments on application page

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -27,10 +27,6 @@ class Application < ApplicationRecord
     latest_deploy_to_each_environment.select { |env, _deploy| environments.include?(env) }
   end
 
-  def interesting_deployments
-    deployments.recent.interesting
-  end
-
   def staging_and_production_in_sync?
     return @staging_and_production_in_sync unless @staging_and_production_in_sync.nil?
     staging = latest_deploy_to_each_environment["staging"]

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -6,9 +6,6 @@ class Deployment < ApplicationRecord
 
   scope :recent, lambda { order("created_at DESC").limit(25) }
 
-  # Ignore automatic deployment of the release branch to preview
-  scope :interesting, lambda { where.not(environment: 'preview', version: 'release') }
-
   def self.environments
     Deployment.select('DISTINCT environment').map(&:environment)
   end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -122,38 +122,36 @@
   </tbody>
 </table>
 
-<% if @application.interesting_deployments.any? %>
-  <h2>Recent deployments</h2>
-  <table class="table table-striped table-bordered table-hover" data-module="filterable-table">
-    <thead>
-      <tr class='table-header'>
-        <th scope="col" class="headerSortDown">Date</th>
-        <th scope="col">Environment</th>
-        <th>Release</th>
-      </tr>
-      <tr class="if-no-js-hide table-header-secondary">
-        <td colspan="3">
-          <form>
-            <label for="deployments-filter" class="rm">Filter Deployments</label>
-            <input id="deployments-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter deployments">
-          </form>
-        </td>
-      </tr>
-    </thead>
-    <tbody>
-    <% @application.interesting_deployments.each do |deployment| %>
-      <tr>
-        <td><%= human_datetime(deployment.created_at) %></td>
-        <td>
-          <% if deployment.production? %>
-            <span class="label label-danger"><%= deployment.environment %></span>
-          <% else %>
-            <span class="label label-default"><%= deployment.environment %></span>
-          <% end %>
-        </td>
-        <td><%= github_tag_link_to(@application, deployment.version) %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-<% end %>
+<h2>Recent deployments</h2>
+<table class="table table-striped table-bordered table-hover" data-module="filterable-table">
+  <thead>
+    <tr class='table-header'>
+      <th scope="col" class="headerSortDown">Date</th>
+      <th scope="col">Environment</th>
+      <th>Release</th>
+    </tr>
+    <tr class="if-no-js-hide table-header-secondary">
+      <td colspan="3">
+        <form>
+          <label for="deployments-filter" class="rm">Filter Deployments</label>
+          <input id="deployments-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter deployments">
+        </form>
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+  <% @application.deployments.each do |deployment| %>
+    <tr>
+      <td><%= human_datetime(deployment.created_at) %></td>
+      <td>
+        <% if deployment.production? %>
+          <span class="label label-danger"><%= deployment.environment %></span>
+        <% else %>
+          <span class="label label-default"><%= deployment.environment %></span>
+        <% end %>
+      </td>
+      <td><%= github_tag_link_to(@application, deployment.version) %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
This hasn't worked since we've moved to "integration" rather than "preview". We don't seem to need the filtering so this commit removes the code.