### PR TITLE
Show only last 25 deploys on application page

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -40,6 +40,7 @@ class ApplicationsController < ApplicationController
     end
 
     @github_available = true
+    @latest_deployments = @application.deployments.newest_first.limit(25)
   rescue Octokit::NotFound => e
     @github_available = false
     @github_error = e

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -2,7 +2,7 @@ class DeploymentsController < ApplicationController
   before_action :redirect_if_read_only_user, only: [:new, :create]
 
   def recent
-    @deployments = Deployment.includes(:application).recent
+    @deployments = Deployment.includes(:application).newest_first.limit(25)
   end
 
   def new

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -4,7 +4,7 @@ class Deployment < ApplicationRecord
 
   validates_presence_of :version, :environment, :application_id
 
-  scope :recent, lambda { order("created_at DESC").limit(25) }
+  scope :newest_first, -> { order("created_at DESC") }
 
   def self.environments
     Deployment.select('DISTINCT environment').map(&:environment)

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -140,7 +140,7 @@
     </tr>
   </thead>
   <tbody>
-  <% @application.deployments.each do |deployment| %>
+  <% @latest_deployments.each do |deployment| %>
     <tr>
       <td><%= human_datetime(deployment.created_at) %></td>
       <td>


### PR DESCRIPTION
https://github.com/alphagov/release/pull/116 inadvertently removed the `recent` scope from the deployments. This also did the sorting so now the latest deployments list looks weird. This commit replaces the scope with a thing that's unambiguous and does just one thing.