### PR TITLE
Avoid errors when application status notes are too big

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,3 +51,13 @@ table.commits td.hash,
     color: #fff;
   }
 }
+
+.alert-alert {
+  @extend .alert-info;
+}
+.alert-error {
+  @extend .alert-danger;
+}
+.alert-notice {
+  @extend .alert-success;
+}

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -82,7 +82,7 @@ class ApplicationsController < ApplicationController
     if @application.valid? && @application.save
       redirect_to @application, flash: { notice: "Successfully created new application" }
     else
-      flash.now[:alert] = "There are some problems with the application"
+      flash.now[:error] = "There are some problems with the application"
       render action: "new"
     end
   end
@@ -91,7 +91,7 @@ class ApplicationsController < ApplicationController
     if @application.update_attributes(application_params)
       redirect_to @application, flash: { notice: "Successfully updated the application" }
     else
-      flash.now[:alert] = "There are some problems with the application"
+      flash.now[:error] = "There are some problems with the application"
       render :edit
     end
   end
@@ -100,7 +100,7 @@ class ApplicationsController < ApplicationController
     if @application.update_attributes(application_notes_params)
       redirect_to applications_path, flash: { notice: "Successfully updated notes" }
     else
-      redirect_to applications_path, flash: { alert: "Failed to update notes" }
+      redirect_to applications_path, flash: { error: "Failed to update notes" }
     end
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -97,7 +97,7 @@ class ApplicationsController < ApplicationController
   end
 
   def update_notes
-    if @application.update_attributes(application_params)
+    if @application.update_attributes(application_notes_params)
       redirect_to applications_path, flash: { notice: "Successfully updated notes" }
     else
       redirect_to applications_path, flash: { alert: "Failed to update notes" }
@@ -113,6 +113,10 @@ private
   def github
     credentials = defined?(GITHUB_CREDENTIALS) ? GITHUB_CREDENTIALS : {}
     @client ||= Octokit::Client.new(credentials)
+  end
+
+  def application_notes_params
+    params.require(:application).permit(:status_notes)
   end
 
   def application_params

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -82,7 +82,7 @@ class ApplicationsController < ApplicationController
     if @application.valid? && @application.save
       redirect_to @application, flash: { notice: "Successfully created new application" }
     else
-      flash[:alert] = "There are some problems with the application"
+      flash.now[:alert] = "There are some problems with the application"
       render action: "new"
     end
   end
@@ -91,7 +91,8 @@ class ApplicationsController < ApplicationController
     if @application.update_attributes(application_params)
       redirect_to @application, flash: { notice: "Successfully updated the application" }
     else
-      redirect_to edit_application_path(@application), flash: { alert: "There are some problems with the application" }
+      flash.now[:alert] = "There are some problems with the application"
+      render :edit
     end
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -7,6 +7,8 @@ class Application < ApplicationRecord
   validates_presence_of :repo, message: 'is required'
   validates_presence_of :domain, message: 'is required'
 
+  validates :name, :repo, :domain, :status_notes, :shortname, length: { maximum: 255 }
+
   validates_format_of :repo, with: /\A[^\s\/]+\/[^\s\/]+\Z/i
 
   validates_uniqueness_of :name, :repo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,4 +22,8 @@ ReleaseApp::Application.routes.draw do
   get '/healthcheck', to: 'application#healthcheck'
 
   root to: redirect("/applications", status: 302)
+
+  if Rails.env.development?
+    mount GovukAdminTemplate::Engine, at: "/style-guide"
+  end
 end

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -217,7 +217,8 @@ class ApplicationsControllerTest < ActionController::TestCase
       should "rerender the form" do
         put :update, params: { id: @app.id, application: { name: "", repo: "new/repo" } }
         @app.reload
-        assert_redirected_to edit_application_path(@app)
+        assert_select "form input#application_name[value='']"
+        assert_select "form input#application_repo[value='new/repo']"
       end
     end
   end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -86,6 +86,36 @@ class ApplicationTest < ActiveSupport::TestCase
 
       assert_equal false, application.archived
     end
+
+    should "be invalid with a name that is too long" do
+      application = Application.new(@atts.merge(name: ("a" * 256)))
+
+      refute application.valid?
+    end
+
+    should "be invalid with a domain that is too long" do
+      application = Application.new(@atts.merge(domain: ("gith" + ("u" * 247) + "b.com")))
+
+      refute application.valid?
+    end
+
+    should "be invalid with a repo that is too long" do
+      application = Application.new(@atts.merge(repo: ("alphagov/my-r" + ("e" * 243) + "po")))
+
+      refute application.valid?
+    end
+
+    should "be invalid with a shortname that is too long" do
+      application = Application.new(@atts.merge(shortname: ("a" * 256)))
+
+      refute application.valid?
+    end
+
+    should "be invalid with status_notes that are too long" do
+      application = Application.new(@atts.merge(status_notes: ("This app is n" + ("o" * 233) + "t working!")))
+
+      refute application.valid?
+    end
   end
 
   context "display datetimes" do


### PR DESCRIPTION
I was editing the notes on an app and instead of saving it generated a 500 error (see: https://errbit.publishing.service.gov.uk/apps/5303593c0da11585f1000112/problems/586e698f6578634737a18b00).  Turns out the limit on status_notes is 255 chars in the db and the db is configured to error if the data being inserted is too big.  The app can easily catch this, so that's what this PR does; it does it for all the fields on the Application model while we're at it.  There's a couple of other minor tweaks for styling the error messages too.