### PR TITLE
Fix missing gem in production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,10 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-require 'ci/reporter/rake/minitest' if Rails.env.test?
-require 'ci/reporter/rake/rspec'
+if Rails.env.test?
+  require 'ci/reporter/rake/minitest'
+  require 'ci/reporter/rake/rspec'
+end
 
 ReleaseApp::Application.load_tasks
 


### PR DESCRIPTION
RSpec is only loaded in the test and development environment, because it's in the `:test, :development` group.

This fixes an error which occurs when trying to deploy to production.