### PR TITLE
Handle Github API errors gracefully

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -84,9 +84,8 @@
     </table>
   <% else %>
     <div class="alert alert-error">
-      Couldn't get data from GitHub:
-      <br />
-      <%= @github_error %>
+      <div>Couldn't get data from GitHub:</div>
+      <div><%= @github_error.message %></div>
     </div>
   <% end %>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -77,9 +77,8 @@
   </table>
 <% else %>
   <div class="alert alert-error">
-    Couldn't get data from GitHub:
-    <br>
-    <%= @github_error %>
+    <div>Couldn't get data from GitHub:</div>
+    <div><%= @github_error.message %></div>
   </div>
 <% end %>
 
@@ -122,36 +121,38 @@
   </tbody>
 </table>
 
-<h2>Recent deployments</h2>
-<table class="table table-striped table-bordered table-hover" data-module="filterable-table">
-  <thead>
-    <tr class='table-header'>
-      <th scope="col" class="headerSortDown">Date</th>
-      <th scope="col">Environment</th>
-      <th>Release</th>
-    </tr>
-    <tr class="if-no-js-hide table-header-secondary">
-      <td colspan="3">
-        <form>
-          <label for="deployments-filter" class="rm">Filter Deployments</label>
-          <input id="deployments-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter deployments">
-        </form>
-      </td>
-    </tr>
-  </thead>
-  <tbody>
-  <% @latest_deployments.each do |deployment| %>
-    <tr>
-      <td><%= human_datetime(deployment.created_at) %></td>
-      <td>
-        <% if deployment.production? %>
-          <span class="label label-danger"><%= deployment.environment %></span>
-        <% else %>
-          <span class="label label-default"><%= deployment.environment %></span>
-        <% end %>
-      </td>
-      <td><%= github_tag_link_to(@application, deployment.version) %></td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>
+<% if @latest_deployments %>
+  <h2>Recent deployments</h2>
+  <table class="table table-striped table-bordered table-hover" data-module="filterable-table">
+    <thead>
+      <tr class='table-header'>
+        <th scope="col" class="headerSortDown">Date</th>
+        <th scope="col">Environment</th>
+        <th>Release</th>
+      </tr>
+      <tr class="if-no-js-hide table-header-secondary">
+        <td colspan="3">
+          <form>
+            <label for="deployments-filter" class="rm">Filter Deployments</label>
+            <input id="deployments-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter deployments">
+          </form>
+        </td>
+      </tr>
+    </thead>
+    <tbody>
+    <% @latest_deployments.each do |deployment| %>
+      <tr>
+        <td><%= human_datetime(deployment.created_at) %></td>
+        <td>
+          <% if deployment.production? %>
+            <span class="label label-danger"><%= deployment.environment %></span>
+          <% else %>
+            <span class="label label-default"><%= deployment.environment %></span>
+          <% end %>
+        </td>
+        <td><%= github_tag_link_to(@application, deployment.version) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -168,6 +168,20 @@ class ApplicationsControllerTest < ActionController::TestCase
         assert_select "a[href='/applications/#{@app.id}/deployments/new']", false
       end
     end
+
+    context "when there is a github API error" do
+      setup do
+        stub_request(:get, "https://api.github.com/repos/#{@app.repo}/tags").to_raise(Octokit::TooManyRequests.new)
+        get :show, params: { id: @app.id }
+      end
+
+      should "show the error message" do
+        assert_select '.alert-error' do
+          assert_select 'div', "Couldn't get data from GitHub:"
+          assert_select 'div', "Octokit::TooManyRequests"
+        end
+      end
+    end
   end
 
   context "GET edit" do


### PR DESCRIPTION
There was a bug in the handling of Github API errors that caused the
app to throw 500 errors.

This change will enable users of the release app to see the exact
error from Github that caused the problem, and will handle the situation
with a 200 status code.