### PR TITLE
Add messaging around github API rate limit reset time.

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -85,7 +85,7 @@
   <% else %>
     <div class="alert alert-error">
       <div>Couldn't get data from GitHub:</div>
-      <div><%= @github_error.message %></div>
+      <div><%= @github_error %></div>
     </div>
   <% end %>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -78,7 +78,7 @@
 <% else %>
   <div class="alert alert-error">
     <div>Couldn't get data from GitHub:</div>
-    <div><%= @github_error.message %></div>
+    <div><%= @github_error %></div>
   </div>
 <% end %>
 


### PR DESCRIPTION
Lots of people seem to be affected by the API rate limits at the moment,
so this adds some messaging to the Release app to show when the rate
limits are going to be reset.

e.g. Github API rate limit exceeded. Rate limit will reset in 5 minutes.