### PR TITLE
Make the button to record a missing deployment work

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -7,8 +7,13 @@ class DeploymentsController < ApplicationController
 
   def new
     default_deploy_time = Time.zone.now.strftime("%e/%m/%Y %H:%M")
-    @deployment = Deployment.new(application_id: deployment_params[:application_id],
-                                 environment: deployment_params[:environment],
+
+    shortname = new_deployment_params[:application_id]
+
+    application_id = Application.where(shortname: shortname).pluck(:id).first
+
+    @deployment = Deployment.new(application_id: application_id,
+                                 environment: new_deployment_params[:environment],
                                  created_at: default_deploy_time)
   end
 
@@ -76,6 +81,13 @@ private
       :id,
       :repo,
       :version,
+    )
+  end
+
+  def new_deployment_params
+    params.permit(
+      :application_id,
+      :environment
     )
   end
 end

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -29,6 +29,18 @@ class DeploymentsControllerTest < ActionController::TestCase
     should "redirect when the user has no deploy permissions" do
       actions_requiring_deploy_permission_redirect(:get, :new)
     end
+
+    should "preselect the application" do
+      FactoryGirl.create(
+        :application,
+        repo: "org/app",
+        name: "Application"
+      )
+
+      get :new, params: { application_id: "app" }
+
+      assert_select '#deployment_application_id option[selected]', 'Application'
+    end
   end
 
   context "POST create" do


### PR DESCRIPTION
There is a button on application pages to manually record a deployment.

This was returning a 400 error because it was requiring a deployment param for the #new action.

It also wasn't populating the form properly from `/$application/deploments/new`, because the parameter is actually a shortname, not an id.