### PR TITLE
Add links from Whitehall releases to monitoring dashboard

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -98,9 +98,21 @@
 
       <div class="col-md-9">
         <h3>Test on Staging</h3>
+        <% if @application.shortname == 'whitehall' %>
+          <p>
+            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+            <a target="_blank" href="https://grafana.staging.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall">Staging dashboard</a>: monitor your deployment to check that it doesn't cause any problems
+          </p>
+        <% end %>
         <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
+        <% if @application.shortname == 'whitehall' %>
+          <p>
+            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+            <a target="_blank" href="https://grafana.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall">Production dashboard</a>: monitor your deployment to check that it doesn't cause any problems
+          </p>
+        <% end %>
         <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
       </div>
     </div>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -333,6 +333,24 @@ class ApplicationsControllerTest < ActionController::TestCase
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select '.alert-warning', 'Do not deploy this without talking to core team first!'
     end
+
+    should "show dashboard links when application is Whitehall" do
+      @app.shortname = "whitehall"
+      @app.save
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall"
+      assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall"
+    end
+
+    should "not show dashboard links for other applications" do
+      @app.shortname = "test_application"
+      @app.save
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
+      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
+    end
   end
 
 private

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -329,7 +329,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select "p.lead .label-danger", @deployment.version
     end
 
-    should "should include status notes as a warning" do
+    should "include status notes as a warning" do
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select '.alert-warning', 'Do not deploy this without talking to core team first!'
     end


### PR DESCRIPTION
Link to a Kibana dashboard with some graphs that are useful to monitor during a deployment.

Only link to the Whitehall prototype dashboard for now because it's the first one we've built. Hardcode the link for now, until we've decided how to generate and configure dashboards for other applications.

Paired with @dwhenry 

https://trello.com/c/IcBRUByV/18-add-link-to-dashboards-in-release-app-and-or-badger
<img width="922" alt="screen shot 2017-04-05 at 16 43 55" src="https://cloud.githubusercontent.com/assets/754712/24713997/1b985dea-1a1f-11e7-984e-c6b53261e5cc.png">
