### PR TITLE
Fix dashboard links

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -101,7 +101,7 @@
         <% if @application.shortname == 'whitehall' %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="https://grafana.staging.publishing.service.gov.uk/dashboard/db/deployment-whitehall">Staging dashboard</a>: monitor your deployment to check that it doesn't cause any problems
+            <a target="_blank" href="https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json">Staging dashboard</a>: monitor your deployment to check that it doesn't cause any problems
           </p>
         <% end %>
         <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
@@ -110,7 +110,7 @@
         <% if @application.shortname == 'whitehall' %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="https://grafana.publishing.service.gov.uk/dashboard/db/deployment-whitehall">Production dashboard</a>: monitor your deployment to check that it doesn't cause any problems
+            <a target="_blank" href="https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json">Production dashboard</a>: monitor your deployment to check that it doesn't cause any problems
           </p>
         <% end %>
         <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -339,8 +339,8 @@ class ApplicationsControllerTest < ActionController::TestCase
       @app.save
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/db/deployment-whitehall"
-      assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/db/deployment-whitehall"
+      assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
+      assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
     end
 
     should "not show dashboard links when application does not have a dashboard" do


### PR DESCRIPTION
When loading grafana dashboards from a file they have are named
`/dashboard/file/<slug>.json` when they are created via the admin
interface they are named `/dashboard/db/<slug>`.

Dashboards loaded from files can't be edited.

https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger

Mobbed with @dwhenry @brenetic @MatMoore 