### PR TITLE
Check grafana API to determine if dashboard exists

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -64,6 +64,8 @@ class ApplicationsController < ApplicationController
 
   def deploy
     @release_tag = params[:tag]
+    @staging_dashboard_url = dashboard_url('grafana.staging.publishing.service.gov.uk', @application.shortname)
+    @production_dashboard_url = dashboard_url('grafana.publishing.service.gov.uk', @application.shortname)
 
     @production_deploy = @application.deployments.last_deploy_to "production"
     if @production_deploy
@@ -145,5 +147,12 @@ private
       :status_notes,
       :task,
     )
+  end
+
+  def dashboard_url(host_name, application_name)
+    uri = URI("https://#{host_name}/api/dashboards/file/deployment_#{application_name}.json")
+    return nil unless Net::HTTP.get_response(uri).is_a?(Net::HTTPSuccess)
+
+    "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"
   end
 end

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -98,19 +98,19 @@
 
       <div class="col-md-9">
         <h3>Test on Staging</h3>
-        <% if @application.shortname == 'whitehall' %>
+        <% if @staging_dashboard_url %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json">Staging dashboard</a>: monitor your deployment to check that it doesn't cause any problems
+            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>: monitor your deployment to check that it doesn't cause any problems
           </p>
         <% end %>
         <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
-        <% if @application.shortname == 'whitehall' %>
+        <% if @production_dashboard_url %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json">Production dashboard</a>: monitor your deployment to check that it doesn't cause any problems
+            <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>: monitor your deployment to check that it doesn't cause any problems
           </p>
         <% end %>
         <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>


### PR DESCRIPTION
Any application may have an available dashboard. Grafana is the source of truth for this, so use its API to check whether to render a link.

Mobbed with @dwhenry @brenetic @MatMoore 
Trello: https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger