### PR TITLE
Remove check of deployment dashboard and add link to all apps

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -150,9 +150,6 @@ private
   end
 
   def dashboard_url(host_name, application_name)
-    uri = URI("https://#{host_name}/api/dashboards/file/deployment_#{application_name}.json")
-    return nil unless Net::HTTP.get_response(uri).is_a?(Net::HTTPSuccess)
-
     "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"
   end
 end

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -98,21 +98,21 @@
 
       <div class="col-md-9">
         <h3>Test on Staging</h3>
-        <% if @staging_dashboard_url %>
-          <p>
-            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>: monitor your deployment to check that it doesn't cause any problems
-          </p>
-        <% end %>
+        <p>
+          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+          <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>:
+          monitor your deployment to check that it doesn't cause any problems.
+          Warning: dashboards are under development, not all apps have dashboards yet.
+        </p>
         <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
-        <% if @production_dashboard_url %>
-          <p>
-            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>: monitor your deployment to check that it doesn't cause any problems
-          </p>
-        <% end %>
+        <p>
+          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+          <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
+          monitor your deployment to check that it doesn't cause any problems.
+          Warning: dashboards are under development, not all apps have dashboards yet.
+        </p>
         <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
       </div>
     </div>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -336,7 +336,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select '.alert-warning', 'Do not deploy this without talking to core team first!'
     end
 
-    should "show dashboard links when application has a dashboard" do
+    should "show dashboard links to application's deployment dashboard" do
       @app.shortname = "whitehall"
       @app.save
       stub_request(:get, 'https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
@@ -345,17 +345,6 @@ class ApplicationsControllerTest < ActionController::TestCase
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
       assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
-    end
-
-    should "not show dashboard links when application does not have a dashboard" do
-      @app.shortname = "test_application"
-      @app.save
-      stub_request(:get, 'https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_test_application.json').to_return(status: '404')
-      stub_request(:get, 'https://grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_test_application.json').to_return(status: '404')
-
-      get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
-      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
     end
   end
 


### PR DESCRIPTION
The Grafana API call which checks whether an app has a deployment dashboard currently fails on non-development environments because hostnames like `grafana.publishing.service.gov.uk` are not available on integration/staging/production.

We plan to update the hostnames and firewall rules so that we can reinstate this check, but in the meantime it is more useful to add a link for every app since the majority of them do have a dashboard.

https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger

We talked about just commenting out the logic, but I've deleted it for two reasons:

- In case we don't have time to sort out the proper solution with infra, and this code is left in for a while.
- We won't want to revert back to exactly what was there before - we don't think the cross-environment checks will work, so we're planning to just check whether the dashboard exists on the _current_ environment, which will require an environment-specific Grafana API URL.