### PR TITLE
Only link to a deployment dashboards which have been created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'friendly_id', '5.1.0'
 
 # GDS gems.
 gem 'gds-sso', '13.0.0'
-gem 'plek', '1.10'
+gem 'plek', '2.0'
 
 gem 'airbrake', '~> 5.5'
 gem 'airbrake-ruby', '1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
       omniauth (~> 1.2)
     parser (2.3.1.4)
       ast (~> 2.2)
-    plek (1.10.0)
+    plek (2.0.0)
     poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -331,7 +331,7 @@ DEPENDENCIES
   mysql2 (= 0.3.18)
   nested_form (= 0.3.1)
   octokit (= 3.1.2)
-  plek (= 1.10)
+  plek (= 2.0)
   poltergeist (~> 1.8.1)
   pry (= 0.10.0)
   rails (~> 5.0)
@@ -348,4 +348,4 @@ DEPENDENCIES
   whenever (= 0.8.2)
 
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -64,8 +64,11 @@ class ApplicationsController < ApplicationController
 
   def deploy
     @release_tag = params[:tag]
-    @staging_dashboard_url = dashboard_url('grafana.staging.publishing.service.gov.uk', @application.shortname)
-    @production_dashboard_url = dashboard_url('grafana.publishing.service.gov.uk', @application.shortname)
+
+    if application_has_dashboard?(@application.shortname)
+      @staging_dashboard_url = dashboard_url('grafana.staging.publishing.service.gov.uk', @application.shortname)
+      @production_dashboard_url = dashboard_url('grafana.publishing.service.gov.uk', @application.shortname)
+    end
 
     @production_deploy = @application.deployments.last_deploy_to "production"
     if @production_deploy
@@ -147,6 +150,27 @@ private
       :status_notes,
       :task,
     )
+  end
+
+  def application_has_dashboard?(application_name)
+    grafana_base_url = Plek.find('grafana')
+    uri = URI("#{grafana_base_url}/api/dashboards/file/deployment_#{application_name}.json")
+    request = Net::HTTP::Get.new(uri.path)
+
+    begin
+      grafana_api_response = Net::HTTP.start(uri.host, uri.port) { |http|
+        http.read_timeout = 2 # seconds
+        http.request(request)
+      }
+    rescue StandardError => e
+      # Do not link to dashboards if Grafana API does not respond. Either
+      # Grafana is not available or it does not exist in this environment (e.g.
+      # development)
+      logger.warn("Failed to call Grafana API at '#{uri}': #{e.message}")
+      return false
+    end
+
+    grafana_api_response.is_a?(Net::HTTPSuccess)
   end
 
   def dashboard_url(host_name, application_name)

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -98,21 +98,23 @@
 
       <div class="col-md-9">
         <h3>Test on Staging</h3>
-        <p>
-          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-          <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>:
-          monitor your deployment to check that it doesn't cause any problems.
-          Warning: dashboards are under development, not all apps have dashboards yet.
-        </p>
+        <% if @staging_dashboard_url %>
+          <p>
+            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>:
+            monitor your deployment to check that it doesn't cause any problems.
+          </p>
+        <% end %>
         <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
-        <p>
-          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-          <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
-          monitor your deployment to check that it doesn't cause any problems.
-          Warning: dashboards are under development, not all apps have dashboards yet.
-        </p>
+        <% if @production_dashboard_url %>
+          <p>
+            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+            <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
+            monitor your deployment to check that it doesn't cause any problems.
+          </p>
+        <% end %>
         <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
       </div>
     </div>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -309,8 +309,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       @app = FactoryGirl.create(:application, status_notes: 'Do not deploy this without talking to core team first!')
       @deployment = FactoryGirl.create(:deployment, application_id: @app.id)
       @release_tag = 'hot_fix_1'
-      stub_request(:get, %r{grafana.publishing.service.gov.uk/api/dashboards/file/deployment_#{@app.shortname}.json}).to_return(status: 404)
-      stub_request(:get, %r{grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_#{@app.shortname}.json}).to_return(status: 404)
+      stub_request(:get, %r{grafana_hostname/api/dashboards/file/deployment_#{@app.shortname}.json}).to_return(status: 404)
       stub_request(:get, "https://api.github.com/repos/#{@app.repo}/tags").to_return(body: [])
       stub_request(:get, "https://api.github.com/repos/#{@app.repo}/commits").to_return(body: [])
       Octokit::Client.any_instance.stubs(:compare)
@@ -318,6 +317,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         .returns(stub("comparison",
                       commits: [],
                       base_commit: nil))
+      Plek.expects(:find).with("grafana").returns("http://grafana_hostname")
     end
 
     should "show that we are trying to deploy the application" do
@@ -336,15 +336,46 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select '.alert-warning', 'Do not deploy this without talking to core team first!'
     end
 
-    should "show dashboard links to application's deployment dashboard" do
+    should "show dashboard links when application has a dashboard" do
       @app.shortname = "whitehall"
       @app.save
-      stub_request(:get, 'https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
-      stub_request(:get, 'https://grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
+      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
       assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
+    end
+
+    should "not show dashboard links when application does not have a dashboard" do
+      @app.shortname = "some_application"
+      @app.save
+      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_some_application.json').to_return(status: '404')
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
+      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
+    end
+
+    should "not show dashboard links when the Grafana API cannot be contacted" do
+      @app.shortname = "some_application"
+      @app.save
+      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_some_application.json')
+        .to_raise("Some error in Grafana")
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
+      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
+    end
+
+    should "not show dashboard links when the Grafana API times out" do
+      @app.shortname = "some_application"
+      @app.save
+      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_some_application.json')
+        .to_timeout
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
+      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
     end
   end
 


### PR DESCRIPTION
Check the Grafana API to determine whether an application has a deployment dashboard, and link to it if so.

This check was previously not possible because the Grafana API hostname could not be accessed from backend application servers.

https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger