### PR TITLE
Fix Grafana API call when checking whether dashboard exists

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -158,7 +158,7 @@ private
     request = Net::HTTP::Get.new(uri.path)
 
     begin
-      grafana_api_response = Net::HTTP.start(uri.host, uri.port) { |http|
+      grafana_api_response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http|
         http.read_timeout = 2 # seconds
         http.request(request)
       }

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -317,7 +317,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         .returns(stub("comparison",
                       commits: [],
                       base_commit: nil))
-      Plek.expects(:find).with("grafana").returns("http://grafana_hostname")
+      Plek.expects(:find).with("grafana").returns("https://grafana_hostname")
     end
 
     should "show that we are trying to deploy the application" do
@@ -339,7 +339,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "show dashboard links when application has a dashboard" do
       @app.shortname = "whitehall"
       @app.save
-      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
@@ -349,7 +349,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "not show dashboard links when application does not have a dashboard" do
       @app.shortname = "some_application"
       @app.save
-      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_some_application.json').to_return(status: '404')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_some_application.json').to_return(status: '404')
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
@@ -359,7 +359,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "not show dashboard links when the Grafana API cannot be contacted" do
       @app.shortname = "some_application"
       @app.save
-      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_some_application.json')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_some_application.json')
         .to_raise("Some error in Grafana")
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
@@ -370,7 +370,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "not show dashboard links when the Grafana API times out" do
       @app.shortname = "some_application"
       @app.save
-      stub_request(:get, 'http://grafana_hostname/api/dashboards/file/deployment_some_application.json')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_some_application.json')
         .to_timeout
 
       get :deploy, params: { id: @app.id, tag: @release_tag }


### PR DESCRIPTION
Ensure the request is made with SSL.

This means that links to the Grafana deployment dashboards will appear on the deployment page if the app has a dashboard. Before this fix, no dashboard links were shown at all.

https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger