### PR TITLE
Add global message functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'uglifier', '2.7.1'
 group :test, :development do
   gem 'better_errors', '2.1.0'
   gem 'binding_of_caller', '0.7.2'
-  gem 'capybara', '~> 2.5.0'
+  gem 'capybara', '~> 2.16.0'
   gem 'poltergeist', '~> 1.8.1'
   gem 'ci_reporter_minitest', '~> 1.0.0'
   gem 'database_cleaner', '~> 1.5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,9 @@ GEM
     bootstrap3-datetimepicker-rails (3.0.0.2)
       momentjs-rails (~> 2.5.0)
     builder (3.2.3)
-    capybara (2.5.0)
-      mime-types (>= 1.16)
+    capybara (2.16.0)
+      addressable
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
@@ -144,6 +145,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.1.0)
     minitest (5.5.1)
     mocha (1.1.0)
@@ -302,7 +304,7 @@ GEM
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
     xml-simple (1.1.4)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -313,7 +315,7 @@ DEPENDENCIES
   better_errors (= 2.1.0)
   binding_of_caller (= 0.7.2)
   bootstrap3-datetimepicker-rails (~> 3.0.0)
-  capybara (~> 2.5.0)
+  capybara (~> 2.16.0)
   ci_reporter_minitest (~> 1.0.0)
   ci_reporter_rspec
   database_cleaner (~> 1.5.3)
@@ -350,4 +352,4 @@ DEPENDENCIES
   whenever (= 0.8.2)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/assets/javascripts/length_counter.js
+++ b/app/assets/javascripts/length_counter.js
@@ -1,0 +1,42 @@
+(function($){
+  var _enableLengthCounting = function () {
+    this.each(function(idx, element) {
+      var $input = $(element),
+          $container = $input.parents('.form-group'),
+          $message = $($input.data('countMessageSelector')).hide(),
+          $count = $message.find('.count'),
+          threshold = $input.data('countMessageThreshold');
+
+          console.log($input)
+          console.log($container)
+          console.log($message)
+
+      if ($input.length > 0) {
+        function checkLength() {
+          var length = $input.val().split('').length;
+
+          $count.text('Current length: '+length);
+          if (length > threshold) {
+            $container.addClass('has-error');
+            $message.addClass('text-danger');
+            $message.show();
+          } else {
+            $container.removeClass('has-error');
+            $message.removeClass('text-danger');
+            if (length > (0.66 * threshold)) {
+              $message.show();
+            }
+          }
+        }
+        $input.bind('keyup', checkLength);
+        checkLength();
+      }
+    })
+  }
+  $.fn.extend({
+    enableLengthCounting: _enableLengthCounting
+  });
+})(jQuery);
+jQuery(function($) {
+  $("[data-length-counting]").enableLengthCounting();
+});

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,11 @@ class ApplicationController < ActionController::Base
     render json: status
   end
 
+  def site_settings
+    @site_settings ||= Site.settings
+  end
+  helper_method :site_settings
+
 private
 
   def error(status_code)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,6 @@ private
   end
 
   def redirect_if_read_only_user
-    redirect_to applications_path unless current_user.may_deploy?
+    redirect_to applications_path, notice: 'You do not have permission to do that' unless current_user.may_deploy?
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,0 +1,20 @@
+class SitesController < ApplicationController
+  before_action :redirect_if_read_only_user
+
+  def show
+  end
+
+  def update
+    if site_settings.update_attributes(site_params)
+      redirect_to root_path, alert: 'Site settings updated'
+    else
+      render :show
+    end
+  end
+
+private
+
+  def site_params
+    params.require(:site).permit(:status_notes)
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,0 +1,10 @@
+class Site < ApplicationRecord
+  validates :status_notes, length: { maximum: 255 }
+  validate :there_can_be_only_one, on: :create
+
+private
+
+  def there_can_be_only_one
+    errors.add(:base, 'There can only be one Site instance') if Site.count > 0
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,6 +2,10 @@ class Site < ApplicationRecord
   validates :status_notes, length: { maximum: 255 }
   validate :there_can_be_only_one, on: :create
 
+  def self.settings
+    Site.first_or_initialize
+  end
+
 private
 
   def there_can_be_only_one

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -65,7 +65,8 @@
                   </div>
                   <%= semantic_form_for application, url: update_notes_application_path(application) do |f| %>
                     <div class="modal-body">
-                      <%= f.input :status_notes, as: :text, input_html: { rows: 5, cols: 50 } %>
+                      <%= f.input :status_notes, as: :text, input_html: { rows: 5, cols: 50, data: { length_counting: 'on', count_message_threshold: 255, count_message_selector: "#notes-length-info-for-app-#{application.id}" } } %>
+                      <p id="notes-length-info-for-app-<%= application.id %>">Notes should be 255 characters or fewer. <span class="count"></span></p>
                     </div>
                     <div class="modal-footer">
                       <%= f.actions do %>

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -63,14 +63,15 @@
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
                     <h3 class="modal-title" id="edit-notes-app-<%= application.id %>Label">Edit notes for <%= application.name %></h3>
                   </div>
-                  <%= form_for application, url: update_notes_application_path(application) do |f| %>
+                  <%= semantic_form_for application, url: update_notes_application_path(application) do |f| %>
                     <div class="modal-body">
-                      <%= f.label :status_notes, "Notes" %>
-                      <%= f.text_area :status_notes, rows: 5, cols: 50, class: "form-control" %>
+                      <%= f.input :status_notes, as: :text, input_html: { rows: 5, cols: 50 } %>
                     </div>
                     <div class="modal-footer">
-                      <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
-                      <%= f.submit "Save", class: "btn btn-primary" %>
+                      <%= f.actions do %>
+                        <%= f.action :cancel, label: 'Cancel', button_html: { class: 'btn btn-default', data: { dismiss: 'modal' }, aria_hidden: true } %>
+                        <%= f.action :submit, label: 'Save', as: :button, button_html: { class: 'btn btn-primary' } %>
+                      <% end %>
                     </div>
                   <% end %>
                 </div>

--- a/app/views/applications/_status_notes.html.erb
+++ b/app/views/applications/_status_notes.html.erb
@@ -1,0 +1,11 @@
+<% if site_settings.status_notes.present? %>
+  <div class="global-status-note alert alert-danger" role="alert">
+    <p><%= site_settings.status_notes %></p>
+  </div>
+<% end %>
+
+<% if application.status_notes.present? %>
+  <div class="application-status-note alert alert-warning" role="alert">
+    <p><%= application.status_notes %></p>
+  </div>
+<% end %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -9,11 +9,7 @@
 </div>
 
 <main>
-  <% if @application.status_notes.present? %>
-    <div class="alert alert-warning" role="alert">
-      <p><%= @application.status_notes %></p>
-    </div>
-  <% end %>
+  <%= render 'status_notes', application: @application %>
 
   <h2>Candidate Release <span class="label label-info"><%= @release_tag %></span></h2>
   <% if @production_deploy %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -16,7 +16,11 @@
   <% end %>
 
   <h2>Candidate Release <span class="label label-info"><%= @release_tag %></span></h2>
-  <p class="lead add-top-margin">Production is <span class="label label-danger"><%= @production_deploy.version %></span> &mdash; deployed at <%= human_datetime(@production_deploy.created_at) %></p>
+  <% if @production_deploy %>
+    <p class="lead add-top-margin">Production is <span class="label label-danger"><%= @production_deploy.version %></span> &mdash; deployed at <%= human_datetime(@production_deploy.created_at) %></p>
+  <% else %>
+    <p class="lead add-top-margin">Production is <span class="label label-danger">not deployed yet</span>!</p>
+  <% end %>
 
   <% unless @application.staging_and_production_in_sync? %>
     <div class="callout callout-danger">
@@ -25,68 +29,70 @@
     </div>
   <% end %>
 
-  <p class="pull-right">
-    <a class="btn btn-default" href="<%= @application.repo_compare_url(@production_deploy.version, @release_tag) %>">
-      <i class="glyphicon glyphicon-new-window add-right-margin"></i>Full Diff
-    </a>
-  </p>
+  <% if @production_deploy %>
+    <p class="pull-right">
+      <a class="btn btn-default" href="<%= @application.repo_compare_url(@production_deploy.version, @release_tag) %>">
+        <i class="glyphicon glyphicon-new-window add-right-margin"></i>Full Diff
+      </a>
+    </p>
 
-  <p class="lead"><%= @commits.length %> <%= 'commit'.pluralize(@commits.length) %></p>
+    <p class="lead"><%= @commits.length %> <%= 'commit'.pluralize(@commits.length) %></p>
 
-  <% if @github_available %>
-    <table class="table table-striped table-bordered table-hover commits" data-module="filterable-table">
-      <thead>
-        <tr class="table-header">
-          <th width="10%">Hash</th>
-          <th width="55%">Message</th>
-          <th width="20%">Author</th>
-          <th width="15%">Date</th>
-        </tr>
-        <tr class="if-no-js-hide table-header-secondary">
-            <td colspan="4">
-              <form>
-                <label for="table-filter" class="rm">Filter commits</label>
-                <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter commits">
-              </form>
-            </td>
+    <% if @github_available %>
+      <table class="table table-striped table-bordered table-hover commits" data-module="filterable-table">
+        <thead>
+          <tr class="table-header">
+            <th width="10%">Hash</th>
+            <th width="55%">Message</th>
+            <th width="20%">Author</th>
+            <th width="15%">Date</th>
           </tr>
-      </thead>
-      <tbody>
-        <% @commits.each do |commit| %>
-          <tr>
-            <td class="hash">
-              <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank" %>
-            </td>
-            <td class="message">
-                <% summary, body = commit[:commit][:message].split(/\n/, 2) %>
-                <a href="<%= "#{@application.repo_url}/commit/#{commit[:sha]}" %>" target="_blank"><%= summary %></a>
-            </td>
-            <td class="author">
-              <% if commit[:author] %>
-                <img height="20" width="20" class="avatar" src="<%= commit[:author][:avatar_url] %>" alt="" />
-              <% end %>
-              <% if commit[:commit][:author] %>
-                <span class="name">
-                  <%= commit[:commit][:author][:name] %>
-                </span>
-              <% end %>
-            </td>
-            <td class="date">
-              <% if commit[:commit][:author] %>
-                <% commit_date = commit[:commit][:author][:date] %>
-                <span class="date"><%= commit_date.to_date.to_s(:short) =%></span>
-                <span class="time"><%= commit_date.to_s(:govuk_time) =%></span>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  <% else %>
-    <div class="alert alert-error">
-      <div>Couldn't get data from GitHub:</div>
-      <div><%= @github_error %></div>
-    </div>
+          <tr class="if-no-js-hide table-header-secondary">
+              <td colspan="4">
+                <form>
+                  <label for="table-filter" class="rm">Filter commits</label>
+                  <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter commits">
+                </form>
+              </td>
+            </tr>
+        </thead>
+        <tbody>
+          <% @commits.each do |commit| %>
+            <tr>
+              <td class="hash">
+                <%= link_to commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank" %>
+              </td>
+              <td class="message">
+                  <% summary, body = commit[:commit][:message].split(/\n/, 2) %>
+                  <a href="<%= "#{@application.repo_url}/commit/#{commit[:sha]}" %>" target="_blank"><%= summary %></a>
+              </td>
+              <td class="author">
+                <% if commit[:author] %>
+                  <img height="20" width="20" class="avatar" src="<%= commit[:author][:avatar_url] %>" alt="" />
+                <% end %>
+                <% if commit[:commit][:author] %>
+                  <span class="name">
+                    <%= commit[:commit][:author][:name] %>
+                  </span>
+                <% end %>
+              </td>
+              <td class="date">
+                <% if commit[:commit][:author] %>
+                  <% commit_date = commit[:commit][:author][:date] %>
+                  <span class="date"><%= commit_date.to_date.to_s(:short) =%></span>
+                  <span class="time"><%= commit_date.to_s(:govuk_time) =%></span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="alert alert-error">
+        <div>Couldn't get data from GitHub:</div>
+        <div><%= @github_error %></div>
+      </div>
+    <% end %>
   <% end %>
 
   <% if current_user.may_deploy? %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -18,11 +18,7 @@
 </div>
 <% end %>
 
-<% if @application.status_notes.present? %>
-  <div class="alert alert-warning" role="alert">
-    <p><%= @application.status_notes %></p>
-  </div>
-<% end %>
+<%= render 'status_notes', application: @application %>
 
 <h2 class="add-bottom-margin">Commit log</h2>
 <% if @github_available %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
   <%= nav_link 'Applications', applications_path %>
   <%= nav_link 'Activity', activity_path %>
   <%= nav_link 'Archived', archived_applications_path %>
+  <%= nav_link 'Site settings', site_path if current_user.may_deploy? %>
 <% end %>
 
 <% content_for :navbar_right do %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -7,7 +7,8 @@
     <%= f.semantic_errors %>
 
     <%= f.inputs do %>
-      <%= f.input :status_notes, as: :text, input_html: { rows: 5, cols: 50 } %>
+      <%= f.input :status_notes, as: :text, input_html: { rows: 5, cols: 50, data: { length_counting: 'on', count_message_threshold: 255, count_message_selector: '.notes-length-info' } } %>
+      <p class="notes-length-info">Notes should be 255 characters or fewer. <span class="count"></span></p>
     <% end %>
     <hr/>
     <%= f.actions do %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, 'Site settings' %>
+
+<h1>Site settings</h1>
+
+<div class="well">
+  <%= semantic_form_for site_settings, url: site_path, method: 'patch' do |f| %>
+    <%= f.semantic_errors %>
+
+    <%= f.inputs do %>
+      <%= f.input :status_notes, as: :text, input_html: { rows: 5, cols: 50 } %>
+    <% end %>
+    <hr/>
+    <%= f.actions do %>
+      <%= f.action :submit, as: :button, button_html: { class: 'btn btn-success' } %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,11 @@ en:
     attributes:
       deploy:
         release: "Release Number"
+  formtastic:
+    labels:
+      site:
+        status_notes: 'Notes'
+    actions:
+      site:
+        create: 'Save settings'
+        update: 'Save settings'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ ReleaseApp::Application.routes.draw do
 
   resources :deployments
 
+  resource :site, only: [:show, :update]
+
   get '/activity', to: 'deployments#recent', as: :activity
 
   get '/healthcheck', to: 'application#healthcheck'

--- a/db/migrate/20171116165801_create_sites.rb
+++ b/db/migrate/20171116165801_create_sites.rb
@@ -1,0 +1,9 @@
+class CreateSites < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sites do |t|
+      t.string :status_notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,42 +12,40 @@
 
 ActiveRecord::Schema.define(version: 20151214151156) do
 
-  create_table "applications", force: :cascade do |t|
-    t.string   "name",         limit: 255
-    t.string   "repo",         limit: 255
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
-    t.string   "status_notes", limit: 255
-    t.string   "shortname",    limit: 255
-    t.string   "domain",       limit: 255
-    t.boolean  "archived",     limit: 1,   default: false, null: false
+  create_table "applications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "repo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "status_notes"
+    t.string "shortname"
+    t.string "domain"
+    t.boolean "archived", default: false, null: false
+    t.index ["name"], name: "index_applications_on_name", unique: true
+    t.index ["repo"], name: "index_applications_on_repo", unique: true
+    t.index ["shortname"], name: "index_applications_on_shortname"
   end
 
-  add_index "applications", ["name"], name: "index_applications_on_name", unique: true, using: :btree
-  add_index "applications", ["repo"], name: "index_applications_on_repo", unique: true, using: :btree
-  add_index "applications", ["shortname"], name: "index_applications_on_shortname", using: :btree
-
-  create_table "deployments", force: :cascade do |t|
-    t.string   "version",        limit: 255
-    t.string   "environment",    limit: 255
-    t.integer  "application_id", limit: 4
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+  create_table "deployments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "version"
+    t.string "environment"
+    t.integer "application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id", "environment", "created_at"], name: "index_deployments_on_application_id_etc"
   end
 
-  add_index "deployments", ["application_id", "environment", "created_at"], name: "index_deployments_on_application_id_etc", using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "name",                    limit: 255
-    t.string   "email",                   limit: 255
-    t.string   "uid",                     limit: 255
-    t.text     "permissions",             limit: 65535
-    t.boolean  "remotely_signed_out",     limit: 1,     default: false
-    t.datetime "created_at",                                            null: false
-    t.datetime "updated_at",                                            null: false
-    t.string   "organisation_slug",       limit: 255
-    t.boolean  "disabled",                limit: 1,     default: false
-    t.string   "organisation_content_id", limit: 255,   default: ""
+  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "name"
+    t.string "email"
+    t.string "uid"
+    t.text "permissions"
+    t.boolean "remotely_signed_out", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "organisation_slug"
+    t.boolean "disabled", default: false
+    t.string "organisation_content_id", default: ""
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151214151156) do
+ActiveRecord::Schema.define(version: 20171116165801) do
 
   create_table "applications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string "name"
@@ -33,6 +33,12 @@ ActiveRecord::Schema.define(version: 20151214151156) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["application_id", "environment", "created_at"], name: "index_deployments_on_application_id_etc"
+  end
+
+  create_table "sites", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "status_notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -15,4 +15,8 @@ FactoryGirl.define do
     sequence(:email) { |n| "winston-#{n}@gov.uk" }
     permissions { %w(signin deploy) }
   end
+
+  factory :site do
+    status_notes "Don't deploy, we're all at a party!"
+  end
 end

--- a/test/functional/sites_controller_test.rb
+++ b/test/functional/sites_controller_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class SitesControllerTest < ActionController::TestCase
+  setup do
+    login_as_stub_user
+  end
+
+  context "GET show" do
+    should "redirect when the user has no deploy permissions" do
+      actions_requiring_deploy_permission_redirect(:get, :show)
+    end
+
+    should 'render the show template with an empty form if no site settings are persisted' do
+      get :show
+      assert_template :show
+
+      assert_select 'form.site[action="/site"]'
+      assert_select 'form.site textarea[name="site[status_notes]"]', ''
+    end
+
+    should 'render the show template with a form filled with the existing site settings' do
+      FactoryGirl.create(:site, status_notes: 'Deploy freeze in place.')
+      get :show
+      assert_template :show
+
+      assert_select 'form.site[action="/site"]'
+      assert_select 'form.site textarea[name="site[status_notes]"]', 'Deploy freeze in place.'
+    end
+  end
+
+  context "PATCH update" do
+    should "redirect when the user has no deploy permissions" do
+      actions_requiring_deploy_permission_redirect(:patch, :update, site: { status_notes: 'No deploys plz!' })
+    end
+
+    should "create some site settings if there are none" do
+      refute Site.settings.persisted?
+
+      patch :update, params: { site: { status_notes: 'Deploy freeze in place.' } }
+
+      assert Site.settings.persisted?
+      assert_equal 'Deploy freeze in place.', Site.settings.status_notes
+    end
+
+    should "update the exiting site settings if they exist" do
+      site_settings = FactoryGirl.create(:site, status_notes: 'Deploys are frozen for now.')
+
+      patch :update, params: { site: { status_notes: 'Deploy freeze in place.' } }
+
+      assert_equal 'Deploy freeze in place.', site_settings.reload.status_notes
+    end
+
+    should "rerender the form if the site settings won't save" do
+      patch :update, params: { site: { status_notes: 'a' * 256 } }
+
+      refute Site.settings.persisted?
+
+      assert_select 'form.site[action="/site"]'
+      assert_select 'form.site textarea[name="site[status_notes]"]', 'a' * 256
+    end
+  end
+end

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -1,0 +1,93 @@
+require 'integration_test_helper'
+
+class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
+  setup do
+    @app1 = FactoryGirl.create(:application)
+    @app2 = FactoryGirl.create(:application)
+    login_as_stub_user
+    stub_deploy_and_release_page_api_requests_for(@app1, 'release_1000')
+    stub_deploy_and_release_page_api_requests_for(@app2, 'release_200')
+  end
+
+  test "we can add a global status note that is shown on all deploy pages" do
+    visit "/"
+
+    click_on @app1.name
+    assert page.has_no_selector?('.global-status-note')
+
+    click_on 'Site settings'
+
+    fill_in 'Notes', with: 'Christmas deploy freeze in place. Emergency deploys only until 2nd Jan'
+    click_on 'Save settings'
+    assert page.has_content?('Site settings updated')
+    assert_equal '/applications', current_path
+
+
+    click_on @app1.name
+    assert page.has_selector?('.global-status-note', text: 'Christmas deploy freeze in place. Emergency deploys only until 2nd Jan'), "Global status note is missing from Application 1 deploys page"
+    click_on 'release_1000'
+    assert page.has_selector?('.global-status-note', text: 'Christmas deploy freeze in place. Emergency deploys only until 2nd Jan'), "Global status note is missing from Application 1 release_1000 tag deploy page"
+
+    visit '/'
+
+    click_on @app2.name
+    assert page.has_selector?('.global-status-note', text: 'Christmas deploy freeze in place. Emergency deploys only until 2nd Jan'), "Global status note is missing from Application 2 deploys page"
+    click_on 'release_200'
+    assert page.has_selector?('.global-status-note', text: 'Christmas deploy freeze in place. Emergency deploys only until 2nd Jan'), "Global status note is missing from Application 2 release_200 tag deploy page"
+
+    click_on 'Site settings'
+    fill_in 'Notes', with: ''
+    click_on 'Save settings'
+    assert page.has_content?('Site settings updated')
+    assert_equal '/applications', current_path
+
+    click_on @app1.name
+    assert page.has_no_selector?('.global-status-note')
+    click_on 'release_1000'
+    assert page.has_no_selector?('.global-status-note')
+
+    visit '/'
+
+    click_on @app2.name
+    assert page.has_no_selector?('.global-status-note')
+    click_on 'release_200'
+    assert page.has_no_selector?('.global-status-note')
+  end
+
+  def stub_deploy_and_release_page_api_requests_for(application, tag)
+    stub_request(:get, "https://api.github.com/repos/#{application.repo}/tags").to_return(body:
+      [
+        {
+          "name": tag,
+          "zipball_url": "https://api.github.com/repos/#{application.repo}/zipball/#{tag}",
+          "tarball_url": "https://api.github.com/repos/#{application.repo}/tarball/#{tag}",
+          "commit": {
+            "sha": "1234567890",
+            "url": "https://api.github.com/repos/#{application.repo}/commits/f45771538251b6ec0d2cc88982797f28916a7878"
+          }
+        }
+      ]
+    )
+    stub_request(:get, "https://api.github.com/repos/#{application.repo}/commits").to_return(body:
+      [
+        {
+          "sha": "1234567890",
+          "commit": {
+            "author": {
+              "name": "A. Human",
+              "email": "a.human@example.com",
+              "date": "2017-11-16T11:55:21Z"
+            },
+            "message": "Made a change to a thing. WIP! DO NOT DEPLOY!",
+            "url": "https://api.github.com/repos/#{application.repo}/git/commits/1234567890",
+            "comment_count": 0,
+          },
+          "url": "https://api.github.com/repos/#{application.repo}/commits/1234567890",
+          "html_url": "https://github.com/alphagov/#{application.repo}/1234567890",
+          "comments_url": "https://api.github.com/repos/#{application.repo}/commits/1234567890/comments"
+        }
+      ]
+    )
+    stub_request(:get, "https://grafana.dev.gov.uk:80/api/dashboards/file/deployment_#{application.shortname}.json").to_return(status: 200, body: "")
+  end
+end

--- a/test/unit/site_test.rb
+++ b/test/unit/site_test.rb
@@ -22,4 +22,16 @@ class SiteTest < ActiveSupport::TestCase
       assert_equal ['There can only be one Site instance'], remake.errors[:base]
     end
   end
+
+  context '.settings' do
+    should "return an unsaved instance if no instance is persisted already" do
+      refute Site.settings.persisted?
+    end
+
+    should "return an the persisted instance if one has be saved already" do
+      site = FactoryGirl.create(:site)
+      assert Site.settings.persisted?
+      assert_equal site, Site.settings
+    end
+  end
 end

--- a/test/unit/site_test.rb
+++ b/test/unit/site_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class SiteTest < ActiveSupport::TestCase
+  context 'validation' do
+    should 'be valid without a status_note' do
+      assert FactoryGirl.build(:site, status_notes: nil).valid?
+    end
+
+    should 'be invalid with a status_note that is longer than 255 chars' do
+      assert FactoryGirl.build(:site, status_notes: 'a' * 254).valid?
+      assert FactoryGirl.build(:site, status_notes: 'a' * 255).valid?
+      refute FactoryGirl.build(:site, status_notes: 'a' * 256).valid?
+    end
+
+    should 'be blocked from creating if there is already a site instance' do
+      original = FactoryGirl.create(:site, status_notes: 'First!')
+      assert original.persisted?
+
+      remake = FactoryGirl.build(:site, status_notes: 'Aw :(')
+      refute remake.valid?
+      refute remake.save
+      assert_equal ['There can only be one Site instance'], remake.errors[:base]
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/W8bleowe/296-add-global-message-to-release-app

We introduce a global singleton Site object for storing global settings.  The only global setting so far is a `status_notes` field (to mirror the existing one on `Application`).  If this is present it will be shown on the application show and deploy pages.

The goal here is to provide a mechanism to warn developers about deploy freezes.  We have planned deploy freezes that everyone should be aware of because we do some messaging beforehand (e.g. Christmas holidays, or the budget), but we also have ad-hoc ones we may put in place during incidents and developers may miss these announcements.

See the commits for the blow-by-blow details.