### PR TITLE
Fix deploy links for puppet

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,6 +38,15 @@ module ApplicationHelper
     "#{application.repo_url}/compare/#{deploy.version}...master"
   end
 
+  def jenkins_deploy_url(application, release_tag, environment)
+    job_name = "Deploy_App"
+    job_name = "Deploy_Puppet" if application.shortname == "puppet"
+    subdomain_prefix = "deploy.staging"
+    subdomain_prefix = "deploy" if environment == "production"
+    escaped_release_tag = CGI.escape(release_tag)
+    "https://#{subdomain_prefix}.publishing.service.gov.uk/job/#{job_name}/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe
+  end
+
 private
 
   def yesterday

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -107,7 +107,7 @@
             monitor your deployment to check that it doesn't cause any problems.
           </p>
         <% end %>
-        <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Staging</a></p>
+        <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "staging") %>">Deploy to Staging</a></p>
 
         <h3>Promote to Production</h3>
         <% if @production_dashboard_url %>
@@ -117,7 +117,7 @@
             monitor your deployment to check that it doesn't cause any problems.
           </p>
         <% end %>
-        <p><a class="btn btn-danger" target="_blank" href="https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=<%= @application.shortname %>&amp;TAG=<%= @release_tag %>">Deploy to Production</a></p>
+        <p><a class="btn btn-danger" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "production") %>">Deploy to Production</a></p>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Puppet uses a different jenkins job to deploy than other apps. There's only so many times you can run the wrong job before you have to fix it.

This PR fixes it.