### PR TITLE
Match Dockerfile ruby version to .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.4-slim
+FROM ruby:2.4.2-slim
 MAINTAINER "govuk-role-platform-accounts-members@digital.cabinet-office.gov.uk"
 
 RUN apt-get update && \


### PR DESCRIPTION
Fix this in advance of us adding a CI check to validate this is true.

https://github.com/alphagov/govuk-puppet/pull/7253