### PR TITLE
Remove new style docker tagging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,5 @@ REPOSITORY = 'release'
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  govuk.buildProject(sassLint: false, newStyleDockerTags: true)
+  govuk.buildProject(sassLint: false)
 }


### PR DESCRIPTION
Reverting this as it has only been implemented here and we have since removed the code

https://trello.com/c/VVL727hf/96-remove-new-style-release-tagging