### PR TITLE
Bump parser gem to 2.5.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     plek (2.1.1)
     poltergeist (1.17.0)


### PR DESCRIPTION
parser 2.5.0.4 was yanked, so update to the latest version.