### PR TITLE
Truncate SHA when linking

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
   end
 
   def github_tag_link_to(app, git_ref)
-    link_to(git_ref, "#{app.repo_url}/tree/#{git_ref}", target: "_blank")
+    link_to(git_ref.truncate(12), "#{app.repo_url}/tree/#{git_ref}", target: "_blank")
   end
 
   def github_compare_to_master(application, deploy)


### PR DESCRIPTION
This avoids weirdness in the tables.

## Before

![screen shot 2018-06-11 at 10 21 57](https://user-images.githubusercontent.com/233676/41223350-6f40a3e4-6d61-11e8-82f6-7fcb8e1d2c6b.png)

## After

![screen shot 2018-06-11 at 10 22 26](https://user-images.githubusercontent.com/233676/41223345-6c686292-6d61-11e8-877a-a719ef96d406.png)


