### PR TITLE
Add app deployments in separate tab

### DIFF
--- a/app/assets/stylesheets/_tabs.scss
+++ b/app/assets/stylesheets/_tabs.scss
@@ -1,0 +1,30 @@
+// https://github.com/alphagov/whitehall-prototype/blob/da490af05e4a88a32101a64a8a8257f7e624fb34/app/assets/sass/application.scss
+$govuk-border-colour: #ccc;
+$govuk-text-colour: #000;
+
+.tabs {
+  padding-left: 0;
+  border-bottom: 1px solid $govuk-border-colour;
+  font-size: 19px;
+
+  li {
+    margin-bottom: -1px;
+    display: inline-block;
+  }
+
+  a {
+    display: block;
+    padding: 15px 20px;
+  }
+
+  .active a {
+    border: 1px solid $govuk-border-colour;
+    border-bottom-color: #fff;
+    text-decoration: none;
+
+    &:link,
+    &:visited {
+      color: $govuk-text-colour;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "activity";
 @import "forms";
 @import "tables";
+@import "tabs";
 
 h1 span.shortname {
   font-family: monospace;

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -42,7 +42,6 @@ class ApplicationsController < ApplicationController
     end
 
     @github_available = true
-    @latest_deployments = @application.deployments.newest_first.limit(25)
   rescue Octokit::TooManyRequests
     @github_available = false
     @github_error = github_rate_limited_error_message

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -1,6 +1,11 @@
 class DeploymentsController < ApplicationController
   before_action :redirect_if_read_only_user, only: [:new, :create]
 
+  def index
+    @application = Application.friendly.find(params[:application_id])
+    @deployments = @application.deployments.newest_first.limit(100)
+  end
+
   def recent
     @deployments = Deployment.includes(:application).newest_first.limit(25)
   end

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -1,5 +1,23 @@
 <% content_for :page_title, @application.name %>
 
-<h1><%= @application.name %></h1>
+<div class="page-header">
+  <h1 class="remove-bottom-margin">
+    <span class="name">Edit <%= @application.name %></span>
+    <span class="shortname">(<%= @application.shortname %>)</span>
+  </h1>
+</div>
+
+<ul class="tabs">
+  <li>
+    <%= link_to "Deploy status", @application %>
+  </li>
+  <li class="active">
+    <%= link_to "Edit", edit_application_path(@application) %>
+  </li>
+  <li>
+    <%= link_to "Recent deployments", application_deployments_path(@application) %>
+  </li>
+</ul>
+
 
 <%= render partial: "form", locals: { application: @application } %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -5,17 +5,24 @@
     <span class="name"><%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>
   </h1>
-  <%= link_to @application.repo_url, @application.repo_url, target: "_blank" %>
 </div>
+
+<ul class="tabs">
+  <li class="active">
+    <%= link_to "Deploy status", @application %>
+  </li>
+  <% if current_user.may_deploy? %>
+    <li>
+      <%= link_to "Edit", edit_application_path(@application) %>
+    </li>
+  <% end %>
+  <li>
+    <%= link_to "Recent deployments", application_deployments_path(@application) %>
+  </li>
+</ul>
 
 <% if @application.archived %>
   <p>This application has been marked as archived.</p>
-<% end %>
-
-<% if current_user.may_deploy? %>
-<div class="btn-group">
-  <%= link_to "Edit", { action: "edit", id: @application.id }, class: "btn btn-default" %>
-</div>
 <% end %>
 
 <%= render 'status_notes', application: @application %>
@@ -116,39 +123,3 @@
     <% end %>
   </tbody>
 </table>
-
-<% if @latest_deployments %>
-  <h2>Recent deployments</h2>
-  <table class="table table-striped table-bordered table-hover" data-module="filterable-table">
-    <thead>
-      <tr class='table-header'>
-        <th scope="col" class="headerSortDown">Date</th>
-        <th scope="col">Environment</th>
-        <th>Release</th>
-      </tr>
-      <tr class="if-no-js-hide table-header-secondary">
-        <td colspan="3">
-          <form>
-            <label for="deployments-filter" class="rm">Filter Deployments</label>
-            <input id="deployments-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter deployments">
-          </form>
-        </td>
-      </tr>
-    </thead>
-    <tbody>
-    <% @latest_deployments.each do |deployment| %>
-      <tr>
-        <td><%= human_datetime(deployment.created_at) %></td>
-        <td>
-          <% if deployment.production? %>
-            <span class="label label-danger"><%= deployment.environment %></span>
-          <% else %>
-            <span class="label label-default"><%= deployment.environment %></span>
-          <% end %>
-        </td>
-        <td><%= github_tag_link_to(@application, deployment.version) %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-<% end %>

--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for :page_title, @application.name %>
+
+<div class="page-header">
+  <h1 class="remove-bottom-margin">
+    <span class="name"><%= @application.name %> deployments</span>
+    <span class="shortname">(<%= @application.shortname %>)</span>
+  </h1>
+</div>
+
+<ul class="tabs">
+  <li>
+    <%= link_to "Deploy status", @application %>
+  </li>
+  <% if current_user.may_deploy? %>
+    <li>
+      <%= link_to "Edit", edit_application_path(@application) %>
+    </li>
+  <% end %>
+  <li class="active">
+    <%= link_to "Recent deployments", application_deployments_path(@application) %>
+  </li>
+</ul>
+
+<%= link_to "Record a missing deployment", new_application_deployment_path(@application), class: "govuk-button" %>
+
+<ul class="list-group activity-list">
+  <% @deployments.each do |deployment| %>
+    <li class="list-group-item deployment to_<%= deployment.environment %>">
+      <h2>
+        <em><%= link_to deployment.application.name, application_path(deployment.application) %></em>
+        <%= deployment.version %> to <em><%= deployment.environment %></em>
+      </h2>
+      <p><%= human_datetime deployment.created_at %></p>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
This moves the application deployments into a separate page. To do so we add tab navigation, which we also use to link to the edit page (which is a button now).

This is part of a spike into using new admin patterns on GOV.UK. This change will make it easier to experiment with the new patterns.

## Screenies

<img width="1478" alt="screen shot 2018-06-11 at 10 43 10" src="https://user-images.githubusercontent.com/233676/41225084-e6aaeae4-6d65-11e8-9fb8-8d3a27511de5.png">
<img width="1478" alt="screen shot 2018-06-11 at 10 43 13" src="https://user-images.githubusercontent.com/233676/41225083-e68cc636-6d65-11e8-9481-2c4a1f33458b.png">
<img width="1478" alt="screen shot 2018-06-11 at 10 43 15" src="https://user-images.githubusercontent.com/233676/41225082-e667b3be-6d65-11e8-82db-6d647984c200.png">


https://trello.com/c/09fVPrRN