### PR TITLE
Highlight release tags in the recent deployments table

### DIFF
--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -27,8 +27,8 @@
   <% @deployments.each do |deployment| %>
     <li class="list-group-item deployment to_<%= deployment.environment %>">
       <h2>
-        <em><%= link_to deployment.application.name, application_path(deployment.application) %></em>
-        <%= deployment.version %> to <em><%= deployment.environment %></em>
+        <em><%= github_tag_link_to(@application, deployment.version) %></em>
+        to <em><%= deployment.environment %></em>
       </h2>
       <p><%= human_datetime deployment.created_at %></p>
     </li>


### PR DESCRIPTION
Previously the application name was bold, and linked to the
application page. This isn't very useful, as this page describes
releases for a single application.

Instead, make the release tag more prominent, and link to GitHub.

## Before
![previous](https://user-images.githubusercontent.com/1130010/41244775-04c56634-6d9e-11e8-953e-c83801cd8a1e.png)
## After
![after](https://user-images.githubusercontent.com/1130010/41244774-047914b4-6d9e-11e8-8c2a-4ebb36027575.png)

