### PR TITLE
Truncate fewer characters in release tag

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
   end
 
   def github_tag_link_to(app, git_ref)
-    link_to(git_ref.truncate(12), "#{app.repo_url}/tree/#{git_ref}", target: "_blank")
+    link_to(git_ref.truncate(20), "#{app.repo_url}/tree/#{git_ref}", target: "_blank")
   end
 
   def github_compare_to_master(application, deploy)


### PR DESCRIPTION
Fixes https://github.com/alphagov/release/pull/225. It was supposed to shorten the SHA deploy tags for backdrop:

<img width="905" alt="screen shot 2018-06-15 at 15 09 49" src="https://user-images.githubusercontent.com/233676/41472403-43fb7ac4-70ae-11e8-835b-3672e001cc30.png">

But ended up also truncating the WH tags:

<img width="1014" alt="screen shot 2018-06-15 at 15 09 53" src="https://user-images.githubusercontent.com/233676/41472415-4a483eee-70ae-11e8-9b2d-d32d96804921.png">

