### PR TITLE
Expose the previous version of a deploy

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -19,8 +19,8 @@ class Deployment < ApplicationRecord
   def previous_deployment
     @previous_deployment ||= Deployment
       .where(application_id: self.application_id, environment: self.environment)
-      .order("created_at DESC")
-      .offset(1)
+      .where("id < ?", id)
+      .order("id DESC")
       .first
   end
 

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class DeploymentTest < ActiveSupport::TestCase
+  describe '#previous_deployment' do
+    should 'should return the previous version' do
+      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/" + SecureRandom.hex)
+
+      previous = FactoryBot.create(:deployment, application: app, environment: "staging")
+      FactoryBot.create(:deployment, application: app, environment: "production")
+      the_deploy = FactoryBot.create(:deployment, application: app, environment: "staging")
+      FactoryBot.create(:deployment, application: app, environment: "staging")
+
+      assert_equal previous, the_deploy.previous_deployment
+    end
+  end
+end


### PR DESCRIPTION
`Deployment#previous_deployment` is not relative to the deployment, which the name seems to imply (otherwise it should have been a class method). This is fine because we currently only use it to show the previous deployment of the current deployment.

This change will make the method return the actual previous deployment, so that you could do `Deployment.last.previous_deployment.previous_deployment` and get the 3rd newest deployment, instead of just the 2nd newest deployment.

We can use this to create a page for any deploy to show what has been deployed.