### PR TITLE
Fix the layout of the AWS section and change the AWS links to include a stack name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,8 +41,13 @@ module ApplicationHelper
   def jenkins_deploy_url(application, release_tag, environment)
     job_name = "Deploy_App"
     job_name = "Deploy_Puppet" if application.shortname == "puppet"
-    subdomain_prefix = "deploy.staging"
-    subdomain_prefix = "deploy" if environment.include?("production")
+    if environment.start_with?("aws")
+      subdomain_prefix = "deploy.blue.staging"
+      subdomain_prefix = "deploy.blue" if environment.include?("production")
+    else
+      subdomain_prefix = "deploy.staging"
+      subdomain_prefix = "deploy" if environment.include?("production")
+    end
     escaped_release_tag = CGI.escape(release_tag)
     domain = if environment.start_with?("aws")
                "govuk.digital"

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -56,19 +56,19 @@
         <% if @staging_dashboard_url %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            Monitor your deployment to check that it doesn't cause any problems, via the:
-            <a target="_blank" href="<%= @staging_dashboard_url %>">Carrenza Staging dashboard</a>
+            Monitor your deployment to check that it doesn't cause any problems, via the
+            <a target="_blank" href="<%= @staging_dashboard_url %>">Carrenza Staging dashboard</a>.
           </p>
         <% end %>
+        <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "staging") %>">Deploy to Carrenza Staging</a></p>
 
         <% if @aws_staging_dashboard_url %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
             Monitor your deployment to check that it doesn't cause any problems, via the
-            <a target="_blank" href="<%= @aws_staging_dashboard_url %>">AWS Staging dashboard</a>
+            <a target="_blank" href="<%= @aws_staging_dashboard_url %>">AWS Staging dashboard</a>.
           </p>
         <% end %>
-        <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "staging") %>">Deploy to Carrenza Staging</a></p>
         <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "aws_staging") %>">Deploy to AWS Staging</a></p>
 
         <h3>Promote to Production</h3>


### PR DESCRIPTION
- We have non-stack-specific DNS for `<appname>.staging.govuk.digital`,
  but when the redirect to the currently live stack (`blue`) happens,
  the path is not preserved.
- We're not going to be implementing a `green` stack any time soon, so
  hardcode `blue` to reduce confusion.