### PR TITLE
Add pages with deployment stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'uglifier', '4.1.13'
 gem 'whenever', '0.10.0'
 gem 'octicons_helper'
 
+gem 'chartkick'
+
 # GDS gems.
 gem 'gds-sso', '~> 13'
 gem 'plek', '2.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
+    chartkick (2.3.5)
     chronic (0.10.2)
     cliver (0.3.2)
     coderay (1.1.2)
@@ -308,6 +309,7 @@ DEPENDENCIES
   better_errors (= 2.4.0)
   binding_of_caller (= 0.8.0)
   capybara (~> 3.3.1)
+  chartkick
   database_cleaner (~> 1.7.0)
   factory_bot_rails
   friendly_id (= 5.2.4)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,6 @@
 //= require jquery_nested_form
 //= require jquery.tablesorter.min
 //= require jquery.autogrowtextarea
+//= require Chart.bundle
+//= require chartkick
 //= require_tree .

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationsController < ApplicationController
   before_action :redirect_if_read_only_user, only: %i[new edit create update update_notes]
-  before_action :find_application, only: %i[show edit update update_notes deploy]
+  before_action :find_application, only: %i[show edit update update_notes deploy stats]
 
   include ActionView::Helpers::DateHelper
 
@@ -12,6 +12,10 @@ class ApplicationsController < ApplicationController
   def archived
     @environments = %w(staging production)
     @applications = Application.where(archived: true)
+  end
+
+  def stats
+    @stats = DeploymentStats.new(Deployment.where(application_id: @application.id))
   end
 
   def show

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,0 +1,5 @@
+class StatsController < ApplicationController
+  def index
+    @stats = DeploymentStats.new
+  end
+end

--- a/app/models/deployment_stats.rb
+++ b/app/models/deployment_stats.rb
@@ -1,0 +1,29 @@
+class DeploymentStats
+  attr_reader :initial_scope
+
+  def initialize(initial_scope = nil)
+    @initial_scope = initial_scope || Deployment
+  end
+
+  def per_month
+    production_deploys
+      .where("deployments.created_at < ?", Date.today.at_beginning_of_month)
+      .group("DATE_FORMAT(deployments.created_at,'%Y-%m')")
+      .count
+  end
+
+  def per_year
+    production_deploys
+      .group("YEAR(deployments.created_at)")
+      .count
+  end
+
+private
+
+  def production_deploys
+    @production_deploys ||= initial_scope
+      .where(environment: "production")
+      .joins(:application)
+      .order("deployments.created_at ASC")
+  end
+end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -19,6 +19,9 @@
   <li>
     <%= link_to "Recent deployments", application_deployments_path(@application) %>
   </li>
+  <li>
+    <%= link_to "Stats", stats_application_path(@application) %>
+  </li>
 </ul>
 
 <% if @application.archived %>

--- a/app/views/applications/stats.html.erb
+++ b/app/views/applications/stats.html.erb
@@ -1,8 +1,8 @@
-<% content_for :page_title, @application.name %>
+<% content_for :page_title, "#{@application.name} stats" %>
 
 <div class="page-header">
   <h1 class="remove-bottom-margin">
-    <span class="name">Edit <%= @application.name %></span>
+    <span class="name"><%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>
   </h1>
 </div>
@@ -11,16 +11,21 @@
   <li>
     <%= link_to "Deploy status", @application %>
   </li>
-  <li class="active">
+  <li>
     <%= link_to "Edit", edit_application_path(@application) %>
   </li>
   <li>
     <%= link_to "Recent deployments", application_deployments_path(@application) %>
   </li>
-  <li>
+  <li class="active">
     <%= link_to "Stats", stats_application_path(@application) %>
   </li>
 </ul>
 
+<h2>Deployments per month</h2>
 
-<%= render partial: "form", locals: { application: @application } %>
+<%= line_chart @stats.per_month, width: "100%", height: "450px", legend: false, download: true %>
+
+<h2>Deployments per year</h2>
+
+<%= column_chart @stats.per_year, width: "100%", height: "250px", legend: false, download: true %>

--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -19,6 +19,9 @@
   <li class="active">
     <%= link_to "Recent deployments", application_deployments_path(@application) %>
   </li>
+  <li>
+    <%= link_to "Stats", stats_application_path(@application) %>
+  </li>
 </ul>
 
 <%= link_to "Record a missing deployment", new_application_deployment_path(@application), class: "govuk-button" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 <% end %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", :media => "all" %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tag %>
   <%= yield :extra_headers %>
 <% end %>
@@ -16,6 +17,7 @@
   <%= nav_link 'Deploys', activity_path %>
   <%= nav_link 'Archived', archived_applications_path %>
   <%= nav_link 'Site settings', site_path if current_user.may_deploy? %>
+  <%= nav_link 'Stats', stats_path %>
 <% end %>
 
 <% content_for :navbar_right do %>
@@ -37,7 +39,6 @@
 <% content_for :footer_version, CURRENT_RELEASE_SHA %>
 
 <% content_for :body_end do %>
-  <%= javascript_include_tag "application" %>
   <%= yield :extra_javascript %>
 <% end %>
 

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, "Deployment stats" %>
+
+<h2>Deployments per month</h2>
+
+<%= line_chart @stats.per_month, width: "100%", height: "450px", legend: false, download: true %>
+
+<h2>Deployments per year</h2>
+
+<%= column_chart @stats.per_year, width: "100%", height: "250px", legend: false, download: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ ReleaseApp::Application.routes.draw do
 
     member do
       get :deploy
+      get :stats
     end
 
     resources :deployments
@@ -22,6 +23,8 @@ ReleaseApp::Application.routes.draw do
   get '/activity', to: 'deployments#recent', as: :activity
 
   get '/healthcheck', to: 'application#healthcheck'
+
+  get '/stats', to: 'stats#index'
 
   root to: redirect("/applications", status: 302)
 

--- a/test/integration/stats_page_test.rb
+++ b/test/integration/stats_page_test.rb
@@ -1,0 +1,21 @@
+require 'integration_test_helper'
+
+class StatsPageTest < ActionDispatch::IntegrationTest
+  setup do
+    login_as_stub_user
+  end
+
+  test "page with global stats" do
+    visit stats_path
+
+    assert page.has_content?("Deployments per month")
+  end
+
+  test "page with stats for an application" do
+    application = FactoryBot.create(:application)
+
+    visit stats_application_path(application)
+
+    assert page.has_content?("Deployments per month")
+  end
+end

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class DeploymentStatsTest < ActiveSupport::TestCase
+  describe '#per_month' do
+    should 'return correct data' do
+      Deployment.delete_all
+
+      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/" + SecureRandom.hex)
+
+      # Don't include deploys from this month (it skews the graph)
+      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
+
+      # Don't include staging deploys
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
+
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+
+      expected = {
+        "2018-01" => 1,
+        "2018-02" => 2,
+      }
+
+      assert_equal(expected, DeploymentStats.new.per_month)
+    end
+  end
+
+  describe '#per_year' do
+    should 'return correct data' do
+      Deployment.delete_all
+
+      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/" + SecureRandom.hex)
+
+      # Don't include staging deploys
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
+
+      FactoryBot.create(:deployment, created_at: "2016-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
+      # Do include deploys from this year
+      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
+
+      expected = {
+        2016 => 1,
+        2017 => 2,
+        Time.zone.now.year => 1,
+      }
+
+      assert_equal(expected, DeploymentStats.new.per_year)
+    end
+  end
+
+  describe '.initialize' do
+    should 'scope the results' do
+      Deployment.delete_all
+
+      other_app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/" + SecureRandom.hex)
+      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/" + SecureRandom.hex)
+
+      # Don't include other apps' deployments
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production")
+
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+
+      expected = {
+        "2018-02" => 2,
+      }
+
+      stats = DeploymentStats.new(Deployment.where(application_id: app.id)).per_month
+
+      assert_equal(expected, stats)
+    end
+  end
+end


### PR DESCRIPTION
This adds 2 new pages:

- A page to show deployments per month and year for all applications
- A tab on the application page to show the deployments per month and year for a specific application

It has 2 use cases at the moment:

- I'm trying to figure out how badgerless deployment affected deployment numbers
(https://github.com/alphagov/govuk-developer-docs/pull/262 / https://trello.com/c/TBsBg11t)
- We may be reporting deployment numbers centrally in GDS to see how teams perform (the "Minimal common software metrics" project)

## Screenies


![screenshot-2018-7-3 deployment stats gov uk release](https://user-images.githubusercontent.com/233676/42226163-27eca32c-7ed6-11e8-8ecc-68bc946ae0dc.png)
![screenshot-2018-7-3 publishing api stats gov uk release](https://user-images.githubusercontent.com/233676/42226164-280b3170-7ed6-11e8-858d-58aa913adf7e.png)
