### PR TITLE
Better show when applications need deploying

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -4,14 +4,16 @@ class ApplicationsController < ApplicationController
 
   include ActionView::Helpers::DateHelper
 
+  ENVIRONMENTS = %w(integration staging production).freeze
+
   def index
-    @environments = %w(integration staging production)
     @applications = Application.where(archived: false)
+    @environments = ENVIRONMENTS
   end
 
   def archived
-    @environments = %w(integration staging production)
     @applications = Application.where(archived: true)
+    @environments = ENVIRONMENTS
   end
 
   def stats

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -5,12 +5,12 @@ class ApplicationsController < ApplicationController
   include ActionView::Helpers::DateHelper
 
   def index
-    @environments = %w(staging production)
+    @environments = %w(integration staging production)
     @applications = Application.where(archived: false)
   end
 
   def archived
-    @environments = %w(staging production)
+    @environments = %w(integration staging production)
     @applications = Application.where(archived: true)
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -4,7 +4,7 @@ class ApplicationsController < ApplicationController
 
   include ActionView::Helpers::DateHelper
 
-  ENVIRONMENTS = %w(integration staging production).freeze
+  ENVIRONMENTS = %w(production staging integration).freeze
 
   def index
     @applications = Application.where(archived: false)

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -29,13 +29,12 @@ class Application < ApplicationRecord
     latest_deploy_to_each_environment.select { |env, _deploy| environments.include?(env) }
   end
 
-  def staging_and_production_in_sync?
-    return @staging_and_production_in_sync unless @staging_and_production_in_sync.nil?
-    staging = latest_deploy_to_each_environment["staging"]
-    production = latest_deploy_to_each_environment["production"]
-    staging_version = staging.nil? ? nil : staging.version
-    production_version = production.nil? ? nil : production.version
-    @staging_and_production_in_sync = (staging_version == production_version)
+  def in_sync?(environments)
+    latest_deploy_to(*environments)
+      .values
+      .map(&:version)
+      .uniq
+      .length <= 1
   end
 
   def fallback_shortname

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -40,11 +40,6 @@
             <% else %>
               N/A
             <% end %>
-            <% if current_user.may_deploy? %>
-              <%= link_to(new_application_deployment_path(application, environment: environment)) do %>
-                <i class="glyphicon glyphicon-plus pull-right" title="Add a missing deployment"></i>
-              <% end %>
-            <% end %>
           </td>
         <% end %>
         <td class="notes">

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -9,7 +9,7 @@
       <th>Notes</th>
     </tr>
     <tr class="if-no-js-hide table-header-secondary">
-      <td colspan="5">
+      <td colspan="<%= 3 + @environments.length %>">
         <form>
           <label for="applications-filter" class="rm">Filter applications</label>
           <input id="applications-filter" autofocus="autofocus" type="text" class="form-control normal js-filter-table-input" placeholder="Filter applications">

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -23,8 +23,8 @@
         <td>
           <%= link_to application.name, application, class: 'js-open-on-submit' %>
         </td>
-        <td class="<%= application.staging_and_production_in_sync? ? "in-sync" : "not-in-sync" %>">
-          <%= application.staging_and_production_in_sync? ? "Yes" : "No" %>
+        <td class="<%= application.in_sync?(@environments) ? "in-sync" : "not-in-sync" %>">
+          <%= application.in_sync?(@environments) ? "Yes" : "No" %>
         </td>
         <% @environments.each do |environment| %>
           <% latest_deploy = application.latest_deploy_to_each_environment[environment] %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -18,13 +18,6 @@
     <p class="lead add-top-margin">Production is <span class="label label-danger">not deployed yet</span>!</p>
   <% end %>
 
-  <% unless @application.staging_and_production_in_sync? %>
-    <div class="callout callout-danger">
-      <div class="callout-title">Production and Staging are not in sync</div>
-      <div class="callout-body">Proceed with caution and check the <a href="<%= @application.repo_compare_url('deployed-to-production', 'deployed-to-staging') %>">differences between production and staging</a></div>
-    </div>
-  <% end %>
-
   <% if @production_deploy %>
     <p class="pull-right">
       <a class="btn btn-default" href="<%= @application.repo_compare_url(@production_deploy.version, @release_tag) %>">

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -23,7 +23,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
     should "show the latest deploy to an environment" do
       get :index
-      assert_select "table tbody tr td:nth-child(3)", /release_x/
+      assert_select "table tbody tr td:nth-child(4)", /release_x/
     end
 
     should "provide a link to compare with master" do


### PR DESCRIPTION
Currently it's hard to tell from the Release app what applications have changes that could be deployed. The intent here is to change "in sync?" to show if any of the environments (including Integration) have different versions deployed, meaning that this field in the table can be used to tell what applications could do with being deployed.

# Changes

 - Show Integration, as well as Staging and Production on the index page
 - Change the order of the environments column, so that Production is on the left
 - Remove the sync warning from the deploy page
 - Change "in sync?" to refer to all environments shown (so now including Integration)

# Before 
![applications-page-current](https://user-images.githubusercontent.com/1130010/42445511-46255516-836b-11e8-8c99-acd42f1a48b6.png)

# After
![applications-page](https://user-images.githubusercontent.com/1130010/42445509-45fb7dcc-836b-11e8-893b-0a5e78e6680f.png)

