### PR TITLE
Change "In sync?" to Status in the applications table

### DIFF
--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -22,13 +22,16 @@ table#application-list {
   tbody {
     tr {
       td {
-        &.in-sync, &.not-in-sync {
+        &.application-status {
           color: white;
         }
-        &.in-sync {
+        &.application-status-all_environments_match {
           background-color: #468847;
         }
-        &.not-in-sync {
+        &.application-status-undeployed_changes_in_integration {
+          background-color: #d95f0e;
+        }
+        &.application-status-production_and_staging_not_in_sync {
           background-color: #b94a48;
         }
         &.deployed-recently {

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -37,6 +37,15 @@ class Application < ApplicationRecord
       .length <= 1
   end
 
+  def status
+    return :production_and_staging_not_in_sync unless in_sync?(%w[production staging])
+    return :undeployed_changes_in_integration unless in_sync?(
+      %w[production staging integration]
+    )
+
+    :all_environments_match
+  end
+
   def fallback_shortname
     self.repo.split('/')[-1] unless self.repo.nil?
   end

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr class='table-header'>
       <th scope="col" class="headerSortDown">Name</th>
-      <th scope="col">In&nbsp;sync?</th>
+      <th scope="col">Status</th>
       <% @environments.each do |environment| %>
         <th scope="col"><%= environment.humanize %></th>
       <% end %>
@@ -23,8 +23,8 @@
         <td>
           <%= link_to application.name, application, class: 'js-open-on-submit' %>
         </td>
-        <td class="<%= application.in_sync?(@environments) ? "in-sync" : "not-in-sync" %>">
-          <%= application.in_sync?(@environments) ? "Yes" : "No" %>
+        <td class="application-status application-status-<%= application.status %>">
+          <%= t("application_status.#{application.status}") %>
         </td>
         <% @environments.each do |environment| %>
           <% latest_deploy = application.latest_deploy_to_each_environment[environment] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,8 @@ en:
     attributes:
       deploy:
         release: "Release Number"
+
+  application_status:
+    production_and_staging_not_in_sync: "Production and Staging not in sync"
+    undeployed_changes_in_integration: "Undeployed changes in Integration"
+    all_environments_match: "All environments match"


### PR DESCRIPTION
This changes the status of applications to be reported as one of 3
states: production and staging differ, integration differs from
production or staging, and all environments match.

Red now goes back to representing differences between production and
staging, and an orange status cell is used to indicate the integration
differences.

This should hopefully make it clearer what state an application is in.

![applications-multiple-colours](https://user-images.githubusercontent.com/1130010/42940827-b40658a2-8b52-11e8-8db6-9de8e0f2e41a.png)
