### PR TITLE
Apps on AWS

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -69,9 +69,13 @@ class ApplicationsController < ApplicationController
     @release_tag = params[:tag]
 
     if application_has_dashboard?(@application.shortname)
-      @staging_dashboard_url = dashboard_url('grafana.staging.publishing.service.gov.uk', @application.shortname)
-      @production_dashboard_url = dashboard_url('grafana.publishing.service.gov.uk', @application.shortname)
-      @aws_staging_dashboard_url = dashboard_url('grafana.staging.govuk.digital', @application.shortname)
+      if @application.on_aws
+        @staging_dashboard_url = dashboard_url('grafana.blue.staging.govuk.digital', @application.shortname)
+        @production_dashboard_url = dashboard_url('grafana.blue.production.govuk.digital', @application.shortname)
+      else
+        @staging_dashboard_url = dashboard_url('grafana.staging.publishing.service.gov.uk', @application.shortname)
+        @production_dashboard_url = dashboard_url('grafana.publishing.service.gov.uk', @application.shortname)
+      end
     end
 
     @production_deploy = @application.deployments.last_deploy_to "production"

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -136,6 +136,7 @@ private
       :shortname,
       :status_notes,
       :task,
+      :on_aws,
     )
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -69,7 +69,7 @@ class ApplicationsController < ApplicationController
     @release_tag = params[:tag]
 
     if application_has_dashboard?(@application.shortname)
-      if @application.on_aws
+      if @application.on_aws?
         @staging_dashboard_url = dashboard_url('grafana.blue.staging.govuk.digital', @application.shortname)
         @production_dashboard_url = dashboard_url('grafana.blue.production.govuk.digital', @application.shortname)
       else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,19 +41,21 @@ module ApplicationHelper
   def jenkins_deploy_url(application, release_tag, environment)
     job_name = "Deploy_App"
     job_name = "Deploy_Puppet" if application.shortname == "puppet"
-    if environment.start_with?("aws")
-      subdomain_prefix = "deploy.blue.staging"
-      subdomain_prefix = "deploy.blue" if environment.include?("production")
+
+    if application.on_aws
+      subdomain_prefix = "deploy.blue.#{environment}"
     else
       subdomain_prefix = "deploy.staging"
       subdomain_prefix = "deploy" if environment.include?("production")
     end
+
     escaped_release_tag = CGI.escape(release_tag)
-    domain = if environment.start_with?("aws")
+    domain = if application.on_aws
                "govuk.digital"
              else
                "publishing.service.gov.uk"
              end
+
     "https://#{subdomain_prefix}.#{domain}/job/#{job_name}/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,7 +42,7 @@ module ApplicationHelper
     job_name = "Deploy_App"
     job_name = "Deploy_Puppet" if application.shortname == "puppet"
 
-    if application.on_aws
+    if application.on_aws?
       subdomain_prefix = "deploy.blue.#{environment}"
     else
       subdomain_prefix = "deploy.staging"
@@ -50,7 +50,7 @@ module ApplicationHelper
     end
 
     escaped_release_tag = CGI.escape(release_tag)
-    domain = if application.on_aws
+    domain = if application.on_aws?
                "govuk.digital"
              else
                "publishing.service.gov.uk"

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -22,6 +22,9 @@
       <tr>
         <td>
           <%= link_to application.name, application, class: 'js-open-on-submit' %>
+          <div style="margin-top: .5rem;">
+            <%= render partial: "provider_badge", locals: { application: application } %>
+          </div>
         </td>
         <td class="application-status application-status-<%= application.status %>">
           <%= t("application_status.#{application.status}") %>

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -6,5 +6,6 @@
                           input_html: { placeholder: @application.fallback_shortname, class: 'form-control input-md-6' } %>
   <%= f.input :status_notes, as: :text, input_html: { class: 'form-control input-md-6' }, hint: "Use for deploy instructions and deploy freezes" %>
   <%= f.input :archived, label: "Archived?" %>
+  <%= f.input :on_aws, label: "Deployed to AWS?" %>
   <%= f.button :submit, class: 'btn btn-success' %>
 <% end %>

--- a/app/views/applications/_provider_badge.html.erb
+++ b/app/views/applications/_provider_badge.html.erb
@@ -1,4 +1,4 @@
-<% if application.on_aws %>
+<% if application.on_aws? %>
   <span class="badge" style="background: rgb(255, 153, 0);">AWS</span>
 <% else %>
   <span class="badge" style="background: #40c0f0;">Carrenza</span>

--- a/app/views/applications/_provider_badge.html.erb
+++ b/app/views/applications/_provider_badge.html.erb
@@ -1,0 +1,5 @@
+<% if application.on_aws %>
+  <span class="badge" style="background: rgb(255, 153, 0);">AWS</span>
+<% else %>
+  <span class="badge" style="background: #40c0f0;">Carrenza</span>
+<% end %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -4,6 +4,7 @@
   <h1 class="remove-bottom-margin">
     <span class="name">Deploy <%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>
+    <%= render partial: "provider_badge", locals: { application: @application } %>
   </h1>
   <%= link_to @application.repo_url, @application.repo_url, target: "_blank" %>
 </div>
@@ -49,19 +50,10 @@
         <p>
           <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
           Monitor your deployment to check that it doesn't cause any problems, via the
-          <a target="_blank" href="<%= @staging_dashboard_url %>">Carrenza Staging dashboard</a>.
+          <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>.
         </p>
       <% end %>
-      <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "staging") %>">Deploy to Carrenza Staging</a></p>
-
-      <% if @aws_staging_dashboard_url %>
-        <p>
-          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-          Monitor your deployment to check that it doesn't cause any problems, via the
-          <a target="_blank" href="<%= @aws_staging_dashboard_url %>">AWS Staging dashboard</a>.
-        </p>
-      <% end %>
-      <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "aws_staging") %>">Deploy to AWS Staging</a></p>
+      <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "staging") %>">Deploy to Staging</a></p>
 
       <h3>Promote to Production</h3>
       <% if @production_dashboard_url %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -4,6 +4,7 @@
   <h1 class="remove-bottom-margin">
     <span class="name">Edit <%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>
+    <%= render partial: "provider_badge", locals: { application: @application } %>
   </h1>
 </div>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -4,6 +4,7 @@
   <h1 class="remove-bottom-margin">
     <span class="name"><%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>
+    <%= render partial: "provider_badge", locals: { application: @application } %>
   </h1>
 </div>
 

--- a/app/views/applications/stats.html.erb
+++ b/app/views/applications/stats.html.erb
@@ -4,6 +4,7 @@
   <h1 class="remove-bottom-margin">
     <span class="name"><%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>
+    <%= render partial: "provider_badge", locals: { application: @application } %>
   </h1>
 </div>
 

--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -4,6 +4,7 @@
   <h1 class="remove-bottom-margin">
     <span class="name"><%= @application.name %> deployments</span>
     <span class="shortname">(<%= @application.shortname %>)</span>
+    <%= render partial: "applications/provider_badge", locals: { application: @application } %>
   </h1>
 </div>
 

--- a/db/migrate/20181025084256_add_on_aws_to_application.rb
+++ b/db/migrate/20181025084256_add_on_aws_to_application.rb
@@ -1,0 +1,5 @@
+class AddOnAwsToApplication < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applications, :on_aws, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_20_100419) do
+ActiveRecord::Schema.define(version: 2018_10_25_084256) do
 
   create_table "applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2018_06_20_100419) do
     t.string "shortname"
     t.string "domain"
     t.boolean "archived", default: false, null: false
+    t.boolean "on_aws", default: false, null: false
     t.index ["name"], name: "index_applications_on_name", unique: true
     t.index ["repo"], name: "index_applications_on_repo", unique: true
     t.index ["shortname"], name: "index_applications_on_shortname"

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -296,6 +296,22 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
       assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
     end
+
+    should "show Carrenza links when application is not on AWS" do
+      @app.update(on_aws: false)
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a[href=?]", "https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=#{@app.shortname}&TAG=hot_fix_1"
+      assert_select "a[href=?]", "https://deploy.publishing.service.gov.uk/job/Deploy_App/parambuild?TARGET_APPLICATION=#{@app.shortname}&TAG=hot_fix_1"
+    end
+
+    should "show AWS links when application is on AWS" do
+      @app.update(on_aws: true)
+
+      get :deploy, params: { id: @app.id, tag: @release_tag }
+      assert_select "a[href=?]", "https://deploy.blue.staging.govuk.digital/job/Deploy_App/parambuild?TARGET_APPLICATION=#{@app.shortname}&TAG=hot_fix_1"
+      assert_select "a[href=?]", "https://deploy.blue.production.govuk.digital/job/Deploy_App/parambuild?TARGET_APPLICATION=#{@app.shortname}&TAG=hot_fix_1"
+    end
   end
 
 private

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -189,7 +189,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true } }
       @app.reload
       assert_equal "new name", @app.name
-      assert_equal @app.on_aws, true
+      assert_equal @app.on_aws?, true
     end
 
     context "invalid request" do

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -176,9 +176,10 @@ class ApplicationsControllerTest < ActionController::TestCase
     end
 
     should "update the application" do
-      put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo" } }
+      put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true } }
       @app.reload
       assert_equal "new name", @app.name
+      assert_equal @app.on_aws, true
     end
 
     context "invalid request" do

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -73,9 +73,19 @@ class ApplicationsControllerTest < ActionController::TestCase
       stub_request(:get, "https://api.github.com/repos/#{@app.repo}/commits").to_return(body: [])
     end
 
-    should "show the application" do
+    should "show the application name" do
       get :show, params: { id: @app.id }
       assert_select "h1 span.name", @app.name
+    end
+
+    should "show the application provider" do
+      get :show, params: { id: @app.id }
+      assert_select "h1 span.badge", "Carrenza"
+
+      @app.update(on_aws: true)
+
+      get :show, params: { id: @app.id }
+      assert_select "h1 span.badge", "AWS"
     end
 
     should "should include status notes as a warning" do

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -87,6 +87,13 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_equal false, application.archived
     end
 
+    should "default to not being on AWS" do
+      @atts.delete :on_aws
+      application = Application.new(@atts)
+
+      assert_equal false, application.on_aws
+    end
+
     should "be invalid with a name that is too long" do
       application = Application.new(@atts.merge(name: ("a" * 256)))
 

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -91,7 +91,7 @@ class ApplicationTest < ActiveSupport::TestCase
       @atts.delete :on_aws
       application = Application.new(@atts)
 
-      assert_equal false, application.on_aws
+      assert_equal false, application.on_aws?
     end
 
     should "be invalid with a name that is too long" do


### PR DESCRIPTION
Allow the ability to mark an application as deployed to AWS and then use that to show relevant deployment buttons that takes the user to the correct Jenkins instance.

<img width="660" alt="screen shot 2018-10-25 at 11 06 24" src="https://user-images.githubusercontent.com/510498/47492944-0bad0980-d846-11e8-918b-1401a45f1fe8.png">

<img width="534" alt="screen shot 2018-10-25 at 11 06 45" src="https://user-images.githubusercontent.com/510498/47492959-149ddb00-d846-11e8-9598-87eb160a30d8.png">

<img width="199" alt="screen shot 2018-10-25 at 11 09 43" src="https://user-images.githubusercontent.com/510498/47493153-7f4f1680-d846-11e8-96a4-44ac8178cacb.png">

[Trello Card](https://trello.com/c/GMsEUaVJ/569-add-functionality-to-release-app-to-define-whether-an-app-is-deployed-to-carrenza-or-aws)