### PR TITLE
Add support for AWS environments

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -32,7 +32,7 @@ class ApplicationsController < ApplicationController
       @latest_deploy_to_each_environment_by_version[deployment.version] << deployment
     end
 
-    @production_deploy = @application.deployments.last_deploy_to "production"
+    @production_deploy = @application.deployments.last_deploy_to production_environment_name
     if @production_deploy
       comparison = Services.github.compare(
         @application.repo,
@@ -78,7 +78,7 @@ class ApplicationsController < ApplicationController
       end
     end
 
-    @production_deploy = @application.deployments.last_deploy_to "production"
+    @production_deploy = @application.deployments.last_deploy_to production_environment_name
     if @production_deploy
       comparison = Services.github.compare(
         @application.repo,
@@ -167,5 +167,13 @@ private
 
   def dashboard_url(host_name, application_name)
     "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"
+  end
+
+  def production_environment_name
+    if @application.on_aws?
+      "production-aws"
+    else
+      "production"
+    end
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -38,9 +38,9 @@ class Application < ApplicationRecord
   end
 
   def status
-    return :production_and_staging_not_in_sync unless in_sync?(%w[production staging])
+    return :production_and_staging_not_in_sync unless in_sync?(production_and_staging_environments)
     return :undeployed_changes_in_integration unless in_sync?(
-      %w[production staging integration]
+      production_and_staging_environments + %w[integration]
     )
 
     :all_environments_match
@@ -60,5 +60,13 @@ class Application < ApplicationRecord
 
   def repo_tag_url(tag)
     "https://#{domain}/#{repo}/releases/tag/#{tag}"
+  end
+
+  def production_and_staging_environments
+    if self.on_aws?
+      %w[production-aws staging-aws]
+    else
+      %w[production staging]
+    end
   end
 end

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -33,7 +33,7 @@ class Deployment < ApplicationRecord
   end
 
   def production?
-    environment == 'production'
+    environment == 'production' || environment == 'production-aws'
   end
 
   def commits
@@ -53,7 +53,7 @@ private
     # Record the deployment to statsd and thence to graphite
   def record_to_statsd
     # Only record production deployments in production graphite
-    if self.environment == "production"
+    if self.environment == "production" || self.environment == "production-aws"
       key = "deploys.#{self.application.shortname}"
       GovukStatsd.increment(key)
     end

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -30,7 +30,8 @@
           <%= t("application_status.#{application.status}") %>
         </td>
         <% @environments.each do |environment| %>
-          <% latest_deploy = application.latest_deploy_to_each_environment[environment] %>
+          <% environment_name = (application.on_aws? && environment != "integration") ? "#{environment}-aws" : environment %>
+          <% latest_deploy = application.latest_deploy_to_each_environment[environment_name] %>
           <td class="<%= latest_deploy.try(:recent?) ? "deployed-recently" : "" %>" title="<%= latest_deploy.try(:created_at) || '' %>">
             <% if latest_deploy %>
               <%= github_tag_link_to(application, latest_deploy.version) %>

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @application do |f| %>
   <%= f.input :name, label: "Name", input_html: { class: 'form-control input-md-6' } %>
   <%= f.input :repo, label: "GitHub repository path", hint: "eg alphagov/publisher", input_html: { class: 'form-control input-md-6' } %>
-  <%= f.input :domain, label: "GitHub domain", hint: "eg github.digital.cabinet-office.gov.uk", input_html: { class: 'form-control input-md-6' } %>
+  <%= f.input :domain, label: "GitHub domain", hint: "eg github.com", input_html: { class: 'form-control input-md-6' } %>
   <%= f.input :shortname, label: "Short name", hint: "for use in graphite metrics, eg whitehall",
                           input_html: { placeholder: @application.fallback_shortname, class: 'form-control input-md-6' } %>
   <%= f.input :status_notes, as: :text, input_html: { class: 'form-control input-md-6' }, hint: "Use for deploy instructions and deploy freezes" %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -47,7 +47,7 @@
               <% tags.each do |tag| %>
                 <% if deployments = @latest_deploy_to_each_environment_by_version[tag[:name]] %>
                   <% deployments.each do |deployment| %>
-                  <p class="deployment <%= 'production' if deployment.environment == 'production' %>">
+                  <p class="deployment <%= 'production' if ['production', 'production-aws'].include?(deployment.environment) %>">
                     <strong class="label label-default env"><%= deployment.environment.humanize %></strong>
                     <span class="rm">at</span>
                     <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %>


### PR DESCRIPTION
This commit adds support for deployment notifications from AWS environments. There may be period where apps are deployed to both Carrenza and AWS, and these changes prevent each notification from overwriting the others.

Trello: https://trello.com/c/aAwyrVNx/606-enable-release-app-notifications-in-aws