### PR TITLE
Update the URLs for the application dashboards

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -146,7 +146,7 @@ private
 
   def application_has_dashboard?(application_name)
     grafana_base_url = Plek.new.external_url_for('grafana')
-    uri = URI("#{grafana_base_url}/api/dashboards/file/deployment_#{application_name}.json")
+    uri = URI("#{grafana_base_url}/api/dashboards/file/#{application_name}.json")
     request = Net::HTTP::Get.new(uri.path)
 
     begin
@@ -166,7 +166,7 @@ private
   end
 
   def dashboard_url(host_name, application_name)
-    "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"
+    "https://#{host_name}/dashboard/file/#{application_name}.json"
   end
 
   def production_environment_name

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -220,7 +220,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       @app = FactoryBot.create(:application, status_notes: 'Do not deploy this without talking to core team first!')
       @deployment = FactoryBot.create(:deployment, application_id: @app.id)
       @release_tag = 'hot_fix_1'
-      stub_request(:get, %r{grafana_hostname/api/dashboards/file/deployment_#{@app.shortname}.json}).to_return(status: 404)
+      stub_request(:get, %r{grafana_hostname/api/dashboards/file/#{@app.shortname}.json}).to_return(status: 404)
       stub_request(:get, "https://api.github.com/repos/#{@app.repo}/tags").to_return(body: [])
       stub_request(:get, "https://api.github.com/repos/#{@app.repo}/commits").to_return(body: [])
       Octokit::Client.any_instance.stubs(:compare)
@@ -258,17 +258,17 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "show dashboard links when application has a dashboard" do
       @app.shortname = "whitehall"
       @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_whitehall.json').to_return(status: '200')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/whitehall.json').to_return(status: '200')
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
-      assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json"
+      assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/whitehall.json"
+      assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/file/whitehall.json"
     end
 
     should "not show dashboard links when application does not have a dashboard" do
       @app.shortname = "some_application"
       @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_some_application.json').to_return(status: '404')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/some_application.json').to_return(status: '404')
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
@@ -278,7 +278,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "not show dashboard links when the Grafana API cannot be contacted" do
       @app.shortname = "some_application"
       @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_some_application.json')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/some_application.json')
         .to_raise("Some error in Grafana")
 
       get :deploy, params: { id: @app.id, tag: @release_tag }
@@ -289,7 +289,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     should "not show dashboard links when the Grafana API times out" do
       @app.shortname = "some_application"
       @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/deployment_some_application.json')
+      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/some_application.json')
         .to_timeout
 
       get :deploy, params: { id: @app.id, tag: @release_tag }

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -86,6 +86,6 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
           "comments_url": "https://api.github.com/repos/#{application.repo}/commits/1234567890/comments"
         }
       ])
-    stub_request(:get, "https://grafana.dev.gov.uk:80/api/dashboards/file/deployment_#{application.shortname}.json").to_return(status: 200, body: "")
+    stub_request(:get, "https://grafana.dev.gov.uk:80/api/dashboards/file/#{application.shortname}.json").to_return(status: 200, body: "")
   end
 end


### PR DESCRIPTION
These are being changed from "deployment" dashboards, in to more
generic application dashboards, so the URL has changed.

Technically, this follows on from the changes in govuk-puppet:
 - https://github.com/alphagov/govuk-puppet/pull/8544
 - https://github.com/alphagov/govuk-puppet/pull/8570

