### PR TITLE
Improve the Release app support for govuk-puppet deploys

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,10 +38,7 @@ module ApplicationHelper
     "#{application.repo_url}/compare/#{deploy.version}...master"
   end
 
-  def jenkins_deploy_url(application, release_tag, environment)
-    job_name = "Deploy_App"
-    job_name = "Deploy_Puppet" if application.shortname == "puppet"
-
+  def jenkins_deploy_app_url(application, release_tag, environment)
     if application.on_aws?
       subdomain_prefix = "deploy.blue.#{environment}"
     else
@@ -56,7 +53,25 @@ module ApplicationHelper
                "publishing.service.gov.uk"
              end
 
-    "https://#{subdomain_prefix}.#{domain}/job/#{job_name}/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe
+    "https://#{subdomain_prefix}.#{domain}/job/Deploy_App/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe
+  end
+
+  def jenkins_deploy_puppet_url(release_tag, environment, aws:)
+    if aws
+      subdomain_prefix = "deploy.blue.#{environment}"
+    else
+      subdomain_prefix = "deploy.staging"
+      subdomain_prefix = "deploy" if environment.include?("production")
+    end
+
+    escaped_release_tag = CGI.escape(release_tag)
+    domain = if aws
+               "govuk.digital"
+             else
+               "publishing.service.gov.uk"
+             end
+
+    "https://#{subdomain_prefix}.#{domain}/job/Deploy_Puppet/parambuild?TAG=#{escaped_release_tag}".html_safe
   end
 
 private

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -45,25 +45,67 @@
     </div>
 
     <div class="col-md-9">
-      <h3>Test on Staging</h3>
-      <% if @staging_dashboard_url %>
+      <% if @application.shortname == 'puppet' %>
+        <h3>Test on Staging</h3>
         <p>
-          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-          Monitor your deployment to check that it doesn't cause any problems, via the
-          <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>.
+          <a class="btn btn-primary add-bottom-margin"
+             target="_blank"
+             href="<%= jenkins_deploy_puppet_url(@release_tag, "staging", aws: false) %>">
+            Deploy to Staging (Carrenza)
+          </a>
+          <a class="btn btn-primary add-bottom-margin"
+             target="_blank"
+             href="<%= jenkins_deploy_puppet_url(@release_tag, "staging", aws: true) %>">
+            Deploy to Staging (AWS)
+          </a>
         </p>
-      <% end %>
-      <p><a class="btn btn-primary add-bottom-margin" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "staging") %>">Deploy to Staging</a></p>
 
-      <h3>Promote to Production</h3>
-      <% if @production_dashboard_url %>
+        <h3>Promote to Production</h3>
         <p>
-          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-          <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
-          monitor your deployment to check that it doesn't cause any problems.
+          <a class="btn btn-danger"
+             target="_blank"
+             href="<%= jenkins_deploy_puppet_url(@release_tag, "production", aws: false) %>">
+            Deploy to Production (Carrenza)
+          </a>
+          <a class="btn btn-danger"
+             target="_blank"
+             href="<%= jenkins_deploy_puppet_url(@release_tag, "production", aws: true) %>">
+            Deploy to Production (AWS)
+          </a>
+        </p>
+      <% else %>
+        <h3>Test on Staging</h3>
+        <% if @staging_dashboard_url %>
+          <p>
+            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+            Monitor your deployment to check that it doesn't cause any problems, via the
+            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>.
+          </p>
+        <% end %>
+        <p>
+          <a class="btn btn-primary add-bottom-margin"
+             target="_blank"
+             href="<%= jenkins_deploy_app_url(@application, @release_tag, "staging") %>">
+            Deploy to Staging
+          </a>
+        </p>
+
+        <h3>Promote to Production</h3>
+        <% if @production_dashboard_url %>
+          <p>
+            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+            <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
+            monitor your deployment to check that it doesn't cause any problems.
+          </p>
+        <% end %>
+        <p>
+          <a class="btn btn-danger"
+             target="_blank"
+             href="<%= jenkins_deploy_app_url(@application, @release_tag, "production") %>">
+            Deploy to Production
+          </a>
         </p>
       <% end %>
-      <p><a class="btn btn-danger" target="_blank" href="<%= jenkins_deploy_url(@application, @release_tag, "production") %>">Deploy to Production</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
We're now using govuk-puppet to manage two sets of Production and
Staging machines, one set running in Carrenza and the other in AWS.

govuk-puppet is unusual in this regard, as it needs deploying to both
environments. These changes make that easier by providing the
necessary links.

![Screenshot from 2019-04-12 13-57-47](https://user-images.githubusercontent.com/1130010/56038896-987b4f00-5d22-11e9-8a5e-7d5dcfee2c63.png)
