### PR TITLE
Move staging dashboard links

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -78,8 +78,8 @@
         <% if @staging_dashboard_url %>
           <p>
             <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            Monitor your deployment to check that it doesn't cause any problems, via the
-            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>.
+            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>:
+            Monitor your deployment to check that it doesn't cause any problems.
           </p>
         <% end %>
         <p>


### PR DESCRIPTION
This puts it in the same place as the production one,
near the appropriate button, which makes it easier to quickly
load both tabs.