### PR TITLE
Always show links to dashboards

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -75,13 +75,11 @@
         </p>
       <% else %>
         <h3>Test on Staging</h3>
-        <% if @staging_dashboard_url %>
-          <p>
-            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>:
-            Monitor your deployment to check that it doesn't cause any problems.
-          </p>
-        <% end %>
+        <p>
+          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+          <a target="_blank" href="<%= @staging_dashboard_url %>">Staging dashboard</a>:
+          Monitor your deployment to check that it doesn't cause any problems.
+        </p>
         <p>
           <a class="btn btn-primary add-bottom-margin"
              target="_blank"
@@ -91,13 +89,11 @@
         </p>
 
         <h3>Promote to Production</h3>
-        <% if @production_dashboard_url %>
-          <p>
-            <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
-            <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
-            monitor your deployment to check that it doesn't cause any problems.
-          </p>
-        <% end %>
+        <p>
+          <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+          <a target="_blank" href="<%= @production_dashboard_url %>">Production dashboard</a>:
+          monitor your deployment to check that it doesn't cause any problems.
+        </p>
         <p>
           <a class="btn btn-danger"
              target="_blank"

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -255,7 +255,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select '.alert-warning', 'Do not deploy this without talking to core team first!'
     end
 
-    should "show dashboard links when application has a dashboard" do
+    should "show dashboard links to application's deployment dashboard" do
       @app.shortname = "whitehall"
       @app.save
       stub_request(:get, 'https://grafana_hostname/api/dashboards/file/whitehall.json').to_return(status: '200')
@@ -263,38 +263,6 @@ class ApplicationsControllerTest < ActionController::TestCase
       get :deploy, params: { id: @app.id, tag: @release_tag }
       assert_select "a[href=?]", "https://grafana.publishing.service.gov.uk/dashboard/file/whitehall.json"
       assert_select "a[href=?]", "https://grafana.staging.publishing.service.gov.uk/dashboard/file/whitehall.json"
-    end
-
-    should "not show dashboard links when application does not have a dashboard" do
-      @app.shortname = "some_application"
-      @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/some_application.json').to_return(status: '404')
-
-      get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
-      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
-    end
-
-    should "not show dashboard links when the Grafana API cannot be contacted" do
-      @app.shortname = "some_application"
-      @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/some_application.json')
-        .to_raise("Some error in Grafana")
-
-      get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
-      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
-    end
-
-    should "not show dashboard links when the Grafana API times out" do
-      @app.shortname = "some_application"
-      @app.save
-      stub_request(:get, 'https://grafana_hostname/api/dashboards/file/some_application.json')
-        .to_timeout
-
-      get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select "a:match('href', ?)", %r"grafana.publishing.service.gov.uk", count: 0
-      assert_select "a:match('href', ?)", %r"grafana.staging.publishing.service.gov.uk", count: 0
     end
 
     should "show Carrenza links when application is not on AWS" do


### PR DESCRIPTION
This effectively reverts [1]. Currently we have an issue where
dashboards have to exist in Carrenza, so that the Release app thinks
it exists, and links to the dashboard in AWS. This "check if the
dashboard exists" feature also blocks removing redundant dashboards
from Carrenza, as the Release app would then stop linking to them.

Therefore, always link to dashboards. I think it's worth having a
dashboard for everything, so this logic shouldn't be used.

1: 5117ce14178d19265fe69a3d967ed7501e2af0d3