### PR TITLE
Make the Gemfile less specific

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,38 +1,38 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.2.2'
+gem 'rails', '~> 5.2'
 
-gem 'friendly_id', '5.2.5'
-gem 'mysql2', '0.4.10'
+gem 'friendly_id', '~> 5'
+gem 'mysql2', '~> 0.4'
 gem 'octicons_helper'
-gem 'octokit', '4.14.0'
-gem 'sass-rails', '~> 5.0.6'
-gem 'simple_form', '~> 4.1'
-gem 'uglifier', '4.1.20'
+gem 'octokit', '~> 4'
+gem 'sass-rails', '~> 5'
+gem 'simple_form', '~> 4'
+gem 'uglifier', '~> 4'
 
 gem 'chartkick'
 
 # GDS gems.
 gem 'gds-sso', '~> 14'
-gem 'govuk_admin_template', '6.7.0'
+gem 'govuk_admin_template', '~> 6'
 gem 'govuk_app_config'
-gem 'plek', '2.1.1'
+gem 'plek', '~> 2'
 
 group :test, :development do
-  gem 'better_errors', '2.5.1'
-  gem 'binding_of_caller', '0.8.0'
-  gem 'capybara', '~> 3.18.0'
-  gem 'database_cleaner', '~> 1.7.0'
+  gem 'better_errors', '~> 2'
+  gem 'binding_of_caller', '~> 0.8'
+  gem 'capybara', '~> 3'
+  gem 'database_cleaner', '~> 1'
   gem 'factory_bot_rails'
   gem 'govuk-lint'
-  gem 'minitest', '5.11.3'
-  gem 'mocha', '1.8.0', require: false
-  gem 'poltergeist', '~> 1.18.1'
-  gem 'pry', '0.12.2'
+  gem 'minitest', '~> 5'
+  gem 'mocha', '~> 1', require: false
+  gem 'poltergeist', '~> 1'
+  gem 'pry', '~> 0.12'
   gem 'rails-controller-testing'
-  gem 'shoulda-context', '1.2.2', require: false
-  gem 'simplecov', '0.16.1', require: false
-  gem 'simplecov-rcov', '0.2.3', require: false
-  gem 'timecop', '0.9.1'
-  gem 'webmock', '~> 3.5.1', require: false
+  gem 'shoulda-context', '~> 1', require: false
+  gem 'simplecov', '~> 0.16', require: false
+  gem 'simplecov-rcov', '~> 0.2', require: false
+  gem 'timecop', '~> 0.9'
+  gem 'webmock', '~> 3', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,35 +313,35 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  better_errors (= 2.5.1)
-  binding_of_caller (= 0.8.0)
-  capybara (~> 3.18.0)
+  better_errors (~> 2)
+  binding_of_caller (~> 0.8)
+  capybara (~> 3)
   chartkick
-  database_cleaner (~> 1.7.0)
+  database_cleaner (~> 1)
   factory_bot_rails
-  friendly_id (= 5.2.5)
+  friendly_id (~> 5)
   gds-sso (~> 14)
   govuk-lint
-  govuk_admin_template (= 6.7.0)
+  govuk_admin_template (~> 6)
   govuk_app_config
-  minitest (= 5.11.3)
-  mocha (= 1.8.0)
-  mysql2 (= 0.4.10)
+  minitest (~> 5)
+  mocha (~> 1)
+  mysql2 (~> 0.4)
   octicons_helper
-  octokit (= 4.14.0)
-  plek (= 2.1.1)
-  poltergeist (~> 1.18.1)
-  pry (= 0.12.2)
-  rails (~> 5.2.2)
+  octokit (~> 4)
+  plek (~> 2)
+  poltergeist (~> 1)
+  pry (~> 0.12)
+  rails (~> 5.2)
   rails-controller-testing
-  sass-rails (~> 5.0.6)
-  shoulda-context (= 1.2.2)
-  simple_form (~> 4.1)
-  simplecov (= 0.16.1)
-  simplecov-rcov (= 0.2.3)
-  timecop (= 0.9.1)
-  uglifier (= 4.1.20)
-  webmock (~> 3.5.1)
+  sass-rails (~> 5)
+  shoulda-context (~> 1)
+  simple_form (~> 4)
+  simplecov (~> 0.16)
+  simplecov-rcov (~> 0.2)
+  timecop (~> 0.9)
+  uglifier (~> 4)
+  webmock (~> 3)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
Specify less about the versions in the Gemfile. This should reduce the
diff size in Dependabot Pull Requests, and make the Gemfile generally
clearer to read. It's fine specifying a very specific version in the
Gemfile, but only if there's a specific reason which is also
mentioned.

The full version information is available in the Gemfile.lock