### PR TITLE
Add breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'chartkick'
 # GDS gems.
 gem 'gds-sso', '~> 14'
 gem 'govuk_admin_template', '~> 6'
+gem 'govuk_publishing_components'
 gem 'govuk_app_config'
 gem 'plek', '~> 3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     docile (1.3.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
@@ -90,6 +92,13 @@ GEM
     ffi (1.10.0)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    gds-api-adapters (59.4.0)
+      addressable
+      link_header
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
     gds-sso (14.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -115,8 +124,23 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
+    govuk_frontend_toolkit (8.2.0)
+      railties (>= 3.1.0)
+      sass (>= 3.2.0)
+    govuk_publishing_components (16.28.0)
+      gds-api-adapters
+      govuk_app_config
+      govuk_frontend_toolkit
+      kramdown
+      plek
+      rails (>= 5.0.0.1)
+      rake
+      rouge
+      sassc-rails (>= 2.0.1)
     hashdiff (0.4.0)
     hashie (3.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
@@ -127,6 +151,8 @@ GEM
     json (2.1.0)
     jwt (2.1.0)
     kgio (2.11.2)
+    kramdown (2.1.0)
+    link_header (0.0.8)
     logstash-event (1.2.02)
     logstasher (1.2.2)
       activesupport (>= 4.0)
@@ -141,6 +167,9 @@ GEM
       mimemagic (~> 0.3.2)
     metaclass (0.0.4)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
@@ -151,9 +180,11 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mysql2 (0.4.10)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    null_logger (0.0.1)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
       jwt (>= 1.0, < 3.0)
@@ -190,6 +221,8 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.1.0)
     rack (2.0.7)
+    rack-cache (1.9.0)
+      rack (>= 0.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -229,6 +262,11 @@ GEM
     regexp_parser (1.5.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rouge (3.3.0)
     rubocop (0.68.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -254,6 +292,12 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
+    sassc-rails (2.1.1)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -289,6 +333,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicode-display_width (1.5.0)
     unicorn (5.4.1)
       kgio (~> 2.6)
@@ -322,6 +369,7 @@ DEPENDENCIES
   govuk-lint
   govuk_admin_template (~> 6)
   govuk_app_config
+  govuk_publishing_components
   minitest (~> 5)
   mocha (~> 1)
   mysql2 (~> 0.4)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,3 +2,5 @@
 //= require Chart.bundle
 //= require chartkick
 //= require_tree .
+//= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/all_components

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import "activity";
 @import "tables";
 @import "tabs";
+@import "govuk_publishing_components/all_components";
 
 h1 span.shortname {
   font-family: monospace;

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -5,4 +5,11 @@ module BreadcrumbHelper
       url: applications_path
     }
   end
+
+  def application_node_crumb(application:)
+    {
+      title: application.name,
+      url: (application_path application)
+    }
+  end
 end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,0 +1,8 @@
+module BreadcrumbHelper
+  def root_crumb
+    {
+      title: "Applications",
+      url: applications_path
+    }
+  end
+end

--- a/app/views/applications/archived.html.erb
+++ b/app/views/applications/archived.html.erb
@@ -1,5 +1,12 @@
 <% content_for :page_title, "Archived applications" %>
 
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Archived applications"
+    }
+  ]
+} %>
 <h1>Archived applications</h1>
 
 <%= render partial: "applications_table", locals: { applications: @applications, environments: @environments } %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -1,6 +1,18 @@
 <% content_for :page_title, @application.name %>
 
 <div class="page-header">
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      root_crumb,
+      {
+        title: @application.name,
+        url: application_path
+      },
+      {
+        title: "Deploy #{@application.name}"
+      }
+    ]
+  } %>
   <h1 class="remove-bottom-margin">
     <span class="name">Deploy <%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -4,10 +4,7 @@
   <%= render "govuk_publishing_components/components/breadcrumbs", {
     breadcrumbs: [
       root_crumb,
-      {
-        title: @application.name,
-        url: application_path
-      },
+      application_node_crumb(application: @application),
       {
         title: "Deploy #{@application.name}"
       }

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -1,6 +1,18 @@
 <% content_for :page_title, @application.name %>
 
 <div class="page-header">
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      root_crumb,
+      {
+        title: @application.name,
+        url: application_path
+      },
+      {
+        title: "Edit #{@application.name}"
+      }
+    ]
+  } %>
   <h1 class="remove-bottom-margin">
     <span class="name">Edit <%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -4,10 +4,7 @@
   <%= render "govuk_publishing_components/components/breadcrumbs", {
     breadcrumbs: [
       root_crumb,
-      {
-        title: @application.name,
-        url: application_path
-      },
+      application_node_crumb(application: @application),
       {
         title: "Edit #{@application.name}"
       }

--- a/app/views/applications/index.html.erb
+++ b/app/views/applications/index.html.erb
@@ -1,5 +1,11 @@
 <% content_for :page_title, "Applications" %>
 
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    root_crumb
+  ]
+} %>
+
 <h1>Applications</h1>
 
 <%= render partial: "applications_table", locals: { applications: @applications, environments: @environments } %>

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -1,6 +1,14 @@
 <% content_for :page_title, "Create new Application" %>
 
-<h1>Create new Application</h1>
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    root_crumb,
+    {
+      title: "Create new application"
+    }
+  ]
+} %>
+<h1>Create new application</h1>
 <p class="lead">Applications are created automatically when first deployed, but you can create them manually if you like.</p>
 
 <%= render partial: "form", locals: { application: @application } %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,6 +1,14 @@
 <% content_for :page_title, @application.name %>
 
 <div class="page-header">
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      root_crumb,
+      {
+        title: @application.name,
+      }
+    ]
+  } %>
   <h1 class="remove-bottom-margin">
     <span class="name"><%= @application.name %></span>
     <span class="shortname">(<%= @application.shortname %>)</span>

--- a/app/views/applications/stats.html.erb
+++ b/app/views/applications/stats.html.erb
@@ -4,10 +4,7 @@
   <%= render "govuk_publishing_components/components/breadcrumbs", {
     breadcrumbs: [
       root_crumb,
-      {
-        title: @application.name,
-        url: application_path
-      },
+      application_node_crumb(application: @application),
       {
         title: "#{@application.name} stats"
       }

--- a/app/views/applications/stats.html.erb
+++ b/app/views/applications/stats.html.erb
@@ -1,8 +1,20 @@
 <% content_for :page_title, "#{@application.name} stats" %>
 
 <div class="page-header">
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      root_crumb,
+      {
+        title: @application.name,
+        url: application_path
+      },
+      {
+        title: "#{@application.name} stats"
+      }
+    ]
+  } %>
   <h1 class="remove-bottom-margin">
-    <span class="name"><%= @application.name %></span>
+    <span class="name"><%= @application.name %> stats</span>
     <span class="shortname">(<%= @application.shortname %>)</span>
     <%= render partial: "provider_badge", locals: { application: @application } %>
   </h1>

--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -5,10 +5,7 @@
   <%= render "govuk_publishing_components/components/breadcrumbs", {
     breadcrumbs: [
       root_crumb,
-      {
-        title: @application.name,
-        url: (application_path @application)
-      },
+      application_node_crumb(application: @application),
       {
         title: "#{@application.name} recent deployments"
       }

--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -2,6 +2,18 @@
 
 <div class="page-header">
   <h1 class="remove-bottom-margin">
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      root_crumb,
+      {
+        title: @application.name,
+        url: (application_path @application)
+      },
+      {
+        title: "#{@application.name} recent deployments"
+      }
+    ]
+  } %>
     <span class="name"><%= @application.name %> deployments</span>
     <span class="shortname">(<%= @application.shortname %>)</span>
     <%= render partial: "applications/provider_badge", locals: { application: @application } %>

--- a/app/views/deployments/new.html.erb
+++ b/app/views/deployments/new.html.erb
@@ -1,5 +1,12 @@
 <% content_for :page_title, "Manually record a deployment" %>
 
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Manually record a deployment"
+    }
+  ]
+} %>
 <h1>Manually record a deployment</h1>
 
 <p class="lead">

--- a/app/views/deployments/recent.html.erb
+++ b/app/views/deployments/recent.html.erb
@@ -1,6 +1,13 @@
 <% content_for :page_title, "Deployment activity" %>
 
 <section>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: "Recent deployments"
+      }
+    ]
+  } %>
   <h1>Recent deployments</h1>
 
   <%= render "deployments_list", deploys: @deployments %>

--- a/app/views/deployments/show.html.erb
+++ b/app/views/deployments/show.html.erb
@@ -1,3 +1,15 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    root_crumb,
+    {
+      title: "Recent deployments",
+      url: activity_path
+    },
+    {
+      title: "Deploy #{@deployment.id} for #{@deployment.application.name}"
+    }
+  ]
+} %>
 <h1>Deploy #<%= @deployment.id %></h1>
 
 <table>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,5 +1,12 @@
 <% content_for :page_title, 'Site settings' %>
 
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Site settings"
+    }
+  ]
+} %>
 <h1>Site settings</h1>
 
 <%= simple_form_for site_settings, url: site_path, method: 'patch' do |f| %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,5 +1,12 @@
 <% content_for :page_title, "Deployment stats" %>
 
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  breadcrumbs: [
+    {
+      title: "Deployments per month"
+    }
+  ]
+} %>
 <h2>Deployments per month</h2>
 
 <%= line_chart @stats.per_month, width: "100%", height: "450px", legend: false, download: true %>

--- a/test/helpers/breadcrumb_helper_test.rb
+++ b/test/helpers/breadcrumb_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class BreadcrumbHelperTest < ActionView::TestCase
+  should 'return a hash of title and url' do
+    app_name = SecureRandom.hex
+    app = FactoryBot.create(:application, name: app_name, repo: "alphagov/" + app_name)
+
+    expected_hash = {
+      title: app_name,
+      url: "/applications/#{app_name}"
+    }
+
+    assert_equal expected_hash, application_node_crumb(application: app)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,3 +40,13 @@ class ActiveSupport::TestCase
     DatabaseCleaner.clean
   end
 end
+
+class ActionView::TestCase
+  setup do
+    DatabaseCleaner.start
+  end
+
+  teardown do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
Add GOV.UK publishing components gem and subsequently use the gem's breadcrumb component to add breadcrumbs into the release app.

### Old

<img width="756" alt="Screen Shot 2019-06-05 at 15 55 32" src="https://user-images.githubusercontent.com/647311/58966578-6c240200-87aa-11e9-9986-504e4cffa22a.png">

### New

<img width="754" alt="Screen Shot 2019-06-05 at 15 55 24" src="https://user-images.githubusercontent.com/647311/58966587-7219e300-87aa-11e9-8fbc-375a5dd430bc.png">


