### PR TITLE
Fix breadcrumb font size

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$govuk-typography-use-rem: false;
+
 @import "govuk_admin_template";
 @import "activity";
 @import "tables";


### PR DESCRIPTION
The breadcrumb in the app is too small. It's like that text in other
places were also wrong. Activating the compatibility mode flag should
address this.

## Before 

![release publishing service gov uk_applications](https://user-images.githubusercontent.com/424772/66313955-23708700-e90b-11e9-91b7-452b7dc2f407.png)

## After

![release integration publishing service gov uk_applications](https://user-images.githubusercontent.com/424772/66313968-2d928580-e90b-11e9-98d2-47c7dd331fc7.png)
