### PR TITLE
fix the search for app records by application name

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -72,7 +72,7 @@ private
   end
 
   def application_by_name
-    existing_apps = Application.where(repo: repo_path, name: params[:application_name])
+    existing_apps = Application.where(name: normalize_app_name(params[:application_name]))
 
     if existing_apps.length.zero?
       Application.create!(name: normalize_app_name(params[:application_name]), repo: repo_path, domain: domain)

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -82,7 +82,7 @@ class DeploymentsControllerTest < ActionController::TestCase
 
       should "create a deployment record for correct app when multiple apps share same repo name" do
         FactoryBot.create(:application, repo: "org/app", name: "test-app-1")
-        app2 = FactoryBot.create(:application, repo: "org/app", name: "test-app-2")
+        app2 = FactoryBot.create(:application, repo: "org/app", name: "test app 2")
         post :create, params: { repo: "org/app", application_by_name: true, application_name: "test-app-2", deployment: { version: "release_123", environment: "staging", jenkins_user_email: "user@example.org", jenkins_user_name: "A User", deployed_sha: "02a570885766dc43d5e2432855bbffb342543906" } }
         deployment = app2.reload.deployments.last
         assert_not_nil deployment


### PR DESCRIPTION
When search for app records by application name, we should use the
normalized app name because the app record is created with the
normalizes app name.

In addition, we should only use the application
name to search because it is unique and there is no need to use the repo
name.