### PR TITLE
Fix spacing between labels

### DIFF
--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -41,7 +41,7 @@
 }
 
 .release__commits-label {
-  display: inline;
+  display: inline-block;
   padding: 5px;
   color: govuk-colour("white");
   border-radius: 5px;


### PR DESCRIPTION
A margin was being added to the commit-labels but this wasn't being properly applied as the labels were `display: inline`. This switches the labels to using `inline-block`.

## Before
<img width="198" alt="Screenshot 2019-12-05 at 11 44 55" src="https://user-images.githubusercontent.com/29889908/70232685-e5e67980-1754-11ea-8347-f8817734253c.png">

## After
<img width="197" alt="Screenshot 2019-12-05 at 11 45 42" src="https://user-images.githubusercontent.com/29889908/70232695-e97a0080-1754-11ea-9776-29fd44ed59d7.png">
