### PR TITLE
Remove heading separator and visually hide redundant table captions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,9 +22,7 @@ $govuk-typography-use-rem: false;
 }
 
 .release__application-header {
-  border-bottom: 1px solid govuk-colour("mid-grey");
-  padding-bottom: 20px;
-  margin-bottom: 30px;
+  margin-bottom: govuk-spacing(9);
 }
 
 .release__stats {

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -10,7 +10,7 @@
 } %>
 
 <div class="release__applications-table" data-filter-applications>
-  <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Applications") do |t| %>
+  <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Applications", { caption_classes: "govuk-visually-hidden" }) do |t| %>
     <%= t.head do %>
       <%= t.header "Name" %>
       <%= t.header "Status" %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -56,7 +56,7 @@
 
 <% if @github_available %>
   <div class="release__commits-table">
-    <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Commit log") do |t| %>
+    <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Commit log", { caption_classes: "govuk-visually-hidden" }) do |t| %>
       <%= t.head do %>
         <%= t.header "Deployed to" %>
         <%= t.header "Release tags" %>
@@ -137,7 +137,7 @@
   margin_bottom: true
 } %>
 
-<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "What's where?") do |t| %>
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "What's where?", { caption_classes: "govuk-visually-hidden" }) do |t| %>
   <%= t.head do %>
     <%= t.header "Environment" %>
     <%= t.header "Current version" %>

--- a/app/views/shared/_commits_table.html.erb
+++ b/app/views/shared/_commits_table.html.erb
@@ -1,5 +1,5 @@
 <div class="release__deploy-commits-table">
-  <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Commits") do |t| %>
+  <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Commits", { caption_classes: "govuk-visually-hidden" }) do |t| %>
     <%= t.head do %>
       <%= t.header "SHA" %>
       <%= t.header "Message" %>


### PR DESCRIPTION
- Remove the heading border as the tabs component underneath provides (in my opinion) enough separation.
- Table captions are useful but visually redundant in these cases, so we're hiding them for sighted users.

### Before
![release integration publishing service gov uk_applications_asset-manager-before](https://user-images.githubusercontent.com/788096/70239364-1503e780-1763-11ea-8ba7-6b433bfd790b.png)

### After
![release integration publishing service gov uk_applications_asset-manager-after](https://user-images.githubusercontent.com/788096/70239380-1c2af580-1763-11ea-8645-0b6ad98d096e.png)
