### PR TITLE
Add instructions to check smokey

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -76,6 +76,9 @@ class ApplicationsController < ApplicationController
       @production_dashboard_url = dashboard_url("grafana.publishing.service.gov.uk", @application.shortname)
     end
 
+
+    @integration_smokey_url = smokey_url(@application, "integration")
+    @staging_smokey_url = smokey_url(@application, "staging")
     @production_deploy = @application.deployments.last_deploy_to production_environment_name
     if @production_deploy
       comparison = Services.github.compare(
@@ -158,6 +161,11 @@ private
 
   def dashboard_url(host_name, application_name)
     "https://#{host_name}/dashboard/file/#{application_name}.json"
+  end
+
+  def smokey_url(application, environment)
+    suffix = helpers.govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    "https://deploy.#{suffix}/job/Smokey"
   end
 
   def production_environment_name

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -68,11 +68,6 @@ class ApplicationsController < ApplicationController
   def deploy
     @release_tag = params[:tag]
 
-    @staging_dashboard_url = dashboard_url(@application, "staging")
-    @production_dashboard_url = dashboard_url(@application, "production")
-
-    @integration_smokey_url = smokey_url(@application, "integration")
-    @staging_smokey_url = smokey_url(@application, "staging")
     @production_deploy = @application.deployments.last_deploy_to production_environment_name
 
     if @production_deploy
@@ -152,16 +147,6 @@ private
       :task,
       :on_aws,
     )
-  end
-
-  def dashboard_url(application, environment)
-    suffix = helpers.govuk_domain_suffix(environment, on_aws: application.on_aws?)
-    "https://grafana.#{suffix}/dashboard/file/#{application.shortname}.json"
-  end
-
-  def smokey_url(application, environment)
-    suffix = helpers.govuk_domain_suffix(environment, on_aws: application.on_aws?)
-    "https://deploy.#{suffix}/job/Smokey"
   end
 
   def production_environment_name

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,40 +38,23 @@ module ApplicationHelper
     "#{application.repo_url}/compare/#{deploy.version}...master"
   end
 
+  def govuk_domain_suffix(environment, on_aws:)
+    return "blue.#{environment}.govuk.digital" if on_aws
+    return "publishing.service.gov.uk" if environment == "production"
+
+    "#{environment}.publishing.service.gov.uk"
+  end
+
   def jenkins_deploy_app_url(application, release_tag, environment)
-    if application.on_aws?
-      subdomain_prefix = "deploy.blue.#{environment}"
-    else
-      subdomain_prefix = "deploy.staging"
-      subdomain_prefix = "deploy" if environment.include?("production")
-    end
-
+    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
     escaped_release_tag = CGI.escape(release_tag)
-    domain = if application.on_aws?
-               "govuk.digital"
-             else
-               "publishing.service.gov.uk"
-             end
-
-    "https://#{subdomain_prefix}.#{domain}/job/Deploy_App/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
+    "https://deploy.#{suffix}/job/Deploy_App/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def jenkins_deploy_puppet_url(release_tag, environment, aws:)
-    if aws
-      subdomain_prefix = "deploy.blue.#{environment}"
-    else
-      subdomain_prefix = "deploy.staging"
-      subdomain_prefix = "deploy" if environment.include?("production")
-    end
-
+    suffix = govuk_domain_suffix(environment, on_aws: aws)
     escaped_release_tag = CGI.escape(release_tag)
-    domain = if aws
-               "govuk.digital"
-             else
-               "publishing.service.gov.uk"
-             end
-
-    "https://#{subdomain_prefix}.#{domain}/job/Deploy_Puppet/parambuild?TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
+    "https://deploy.#{suffix}/job/Deploy_Puppet/parambuild?TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def navigation_items

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,33 +30,6 @@ module ApplicationHelper
     end
   end
 
-  def github_tag_link_to(app, git_ref)
-    link_to(git_ref.truncate(15), "#{app.repo_url}/tree/#{git_ref}", target: "_blank", rel: "noopener", class: "govuk-link")
-  end
-
-  def github_compare_to_master(application, deploy)
-    "#{application.repo_url}/compare/#{deploy.version}...master"
-  end
-
-  def govuk_domain_suffix(environment, on_aws:)
-    return "blue.#{environment}.govuk.digital" if on_aws
-    return "publishing.service.gov.uk" if environment == "production"
-
-    "#{environment}.publishing.service.gov.uk"
-  end
-
-  def jenkins_deploy_app_url(application, release_tag, environment)
-    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
-    escaped_release_tag = CGI.escape(release_tag)
-    "https://deploy.#{suffix}/job/Deploy_App/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
-  end
-
-  def jenkins_deploy_puppet_url(release_tag, environment, aws:)
-    suffix = govuk_domain_suffix(environment, on_aws: aws)
-    escaped_release_tag = CGI.escape(release_tag)
-    "https://deploy.#{suffix}/job/Deploy_Puppet/parambuild?TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
-  end
-
   def navigation_items
     return [] unless current_user
 

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,11 @@
+module UrlHelper
+  def dashboard_url(application, environment)
+    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    "https://grafana.#{suffix}/dashboard/file/#{application.shortname}.json"
+  end
+
+  def smokey_url(application, environment)
+    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    "https://deploy.#{suffix}/job/Smokey"
+  end
+end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -8,4 +8,31 @@ module UrlHelper
     suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
     "https://deploy.#{suffix}/job/Smokey"
   end
+
+  def github_tag_link_to(app, git_ref)
+    link_to(git_ref.truncate(15), "#{app.repo_url}/tree/#{git_ref}", target: "_blank", rel: "noopener", class: "govuk-link")
+  end
+
+  def github_compare_to_master(application, deploy)
+    "#{application.repo_url}/compare/#{deploy.version}...master"
+  end
+
+  def govuk_domain_suffix(environment, on_aws:)
+    return "blue.#{environment}.govuk.digital" if on_aws
+    return "publishing.service.gov.uk" if environment == "production"
+
+    "#{environment}.publishing.service.gov.uk"
+  end
+
+  def jenkins_deploy_app_url(application, release_tag, environment)
+    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    escaped_release_tag = CGI.escape(release_tag)
+    "https://deploy.#{suffix}/job/Deploy_App/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def jenkins_deploy_puppet_url(release_tag, environment, aws:)
+    suffix = govuk_domain_suffix(environment, on_aws: aws)
+    escaped_release_tag = CGI.escape(release_tag)
+    "https://deploy.#{suffix}/job/Deploy_Puppet/parambuild?TAG=#{escaped_release_tag}".html_safe # rubocop:disable Rails/OutputSafety
+  end
 end

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -120,6 +120,11 @@
         <a target="_blank" href="<%= @staging_dashboard_url %>" class="govuk-link">Staging dashboard</a>:
         Monitor your deployment to check that it doesn't cause any problems.
       </p>
+      <p class="govuk-body">
+        <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
+        <a target="_blank" href="<%= @integration_smokey_url %>" class="govuk-link">Integration smokey</a>:
+        Check Smokey has run in Integration and your deploy didn't cause any problems.
+      </p>
       <%= render "govuk_publishing_components/components/button", {
         text: "Deploy to Staging",
         href: jenkins_deploy_app_url(@application, @release_tag, "staging"),
@@ -135,7 +140,12 @@
       <p class="govuk-body">
         <%= octicon "graph", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
         <a target="_blank" href="<%= @production_dashboard_url %>" class="govuk-link">Production dashboard</a>:
-        monitor your deployment to check that it doesn't cause any problems.
+        Monitor your deployment to check that it doesn't cause any problems.
+      </p>
+      <p class="govuk-body">
+        <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
+        <a target="_blank" href="<%= @staging_smokey_url %>" class="govuk-link">Staging smokey</a>:
+        Check Smokey has run in Staging and your deploy didn't cause any problems.
       </p>
       <%= render "govuk_publishing_components/components/button", {
         text: "Deploy to Production",

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -117,12 +117,12 @@
       } %>
       <p class="govuk-body">
         <%= octicon "graph", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-        <a target="_blank" href="<%= @staging_dashboard_url %>" class="govuk-link">Staging dashboard</a>:
+        <a target="_blank" href="<%= dashboard_url(@application, "staging") %>" class="govuk-link">Staging dashboard</a>:
         Monitor your deployment to check that it doesn't cause any problems.
       </p>
       <p class="govuk-body">
         <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-        <a target="_blank" href="<%= @integration_smokey_url %>" class="govuk-link">Integration smokey</a>:
+        <a target="_blank" href="<%= smokey_url(@application, "integration") %>" class="govuk-link">Integration smokey</a>:
         Check Smokey has run in Integration and your deploy didn't cause any problems.
       </p>
       <%= render "govuk_publishing_components/components/button", {
@@ -139,12 +139,12 @@
       } %>
       <p class="govuk-body">
         <%= octicon "graph", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-        <a target="_blank" href="<%= @production_dashboard_url %>" class="govuk-link">Production dashboard</a>:
+        <a target="_blank" href="<%= dashboard_url(@application, "production") %>" class="govuk-link">Production dashboard</a>:
         Monitor your deployment to check that it doesn't cause any problems.
       </p>
       <p class="govuk-body">
         <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-        <a target="_blank" href="<%= @staging_smokey_url %>" class="govuk-link">Staging smokey</a>:
+        <a target="_blank" href="<%= smokey_url(@application, "staging") %>" class="govuk-link">Staging smokey</a>:
         Check Smokey has run in Staging and your deploy didn't cause any problems.
       </p>
       <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
This adds an instrution to check Smokey is passing in the 'preceding'
environment before deploy in the 'following' environment e.g. one should
check integration before deploying to staging.

In order to get the correct URL for the environment and provider, this
DRYs-up the code in the ApplicationHelper and exposes a new method to get
the correct 'govuk_domain_suffix'.

Recent example of how this could be useful: https://github.com/alphagov/smokey/pull/633

<img width="705" alt="Screenshot 2019-12-30 at 16 52 31" src="https://user-images.githubusercontent.com/9029009/71591586-d6283e00-2b24-11ea-99ca-ae0f6b5510e1.png">
