### PR TITLE
Display a banner to note that the 'real' Release app is Production

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,22 +45,17 @@ $govuk-typography-use-rem: false;
   float: right;
 }
 
-.non-production-version {
+.release__non-production-banner {
   @include govuk-font(16);
-  margin: 0 15px 15px 15px;
-  border: 1px solid #B01117;
+  margin: govuk-spacing(3);
+  margin-top: 0;
+  padding: govuk-spacing(3);
+  border: 1px solid $govuk-border-colour;
   background-color: govuk-colour('red');
   color: govuk-colour('white');
-  padding: 1em;
   font-weight: bold;
 
-  a {
-    cursor: pointer;
+  .govuk-link {
     color: govuk-colour('white');
-    text-decoration: underline;
-
-    &:focus {
-      @include govuk-focused-text;
-    }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,23 @@ $govuk-typography-use-rem: false;
 .release__view-diff {
   float: right;
 }
+
+.non-production-version {
+  @include govuk-font(16);
+  margin: 0 15px 15px 15px;
+  border: 1px solid #B01117;
+  background-color: govuk-colour('red');
+  color: govuk-colour('white');
+  padding: 1em;
+  font-weight: bold;
+
+  a {
+    cursor: pointer;
+    color: govuk-colour('white');
+    text-decoration: underline;
+
+    &:focus {
+      @include govuk-focused-text;
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,9 @@
   } %>
 
 <div class="govuk-width-container">
+  <% if GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment != "production" %>
+    <div class="non-production-version">THIS IS NOT THE CANONICAL RELEASE APP. GO TO <a href="https://release.publishing.service.gov.uk">PRODUCTION</a> TO SEE CURRENT RELEASES IN ALL ENVIRONMENTS.</div>
+  <% end %>
   <main class="govuk-main-wrapper govuk-!-padding-top-2" id="main-content" role="main">
     <% [:notice, :alert, :error].select { |k| flash[k].present? }.each do |k| %>
         <% if k.eql?(:notice) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
 
 <div class="govuk-width-container">
   <% if GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment != "production" %>
-    <div class="non-production-version">THIS IS NOT THE CANONICAL RELEASE APP. GO TO <a href="https://release.publishing.service.gov.uk">PRODUCTION</a> TO SEE CURRENT RELEASES IN ALL ENVIRONMENTS.</div>
+    <div class="release__non-production-banner">THIS IS NOT THE CANONICAL RELEASE APP. GO TO <a class="govuk-link" href="https://release.publishing.service.gov.uk">PRODUCTION</a> TO SEE CURRENT RELEASES IN ALL ENVIRONMENTS.</div>
   <% end %>
   <main class="govuk-main-wrapper govuk-!-padding-top-2" id="main-content" role="main">
     <% [:notice, :alert, :error].select { |k| flash[k].present? }.each do |k| %>


### PR DESCRIPTION
- There's been some confusion recently over people looking at
  `release.integration` expecting to see their most recent integration
  release, and `release.staging` with the same for staging.
- This does not happen. The release app is deployed to all environments
  like any other app, which also means it has its data synced from
  production nightly.
- The canonical release app is the Production release app -
  https://release.publishing.service.gov.uk - that shows every release
  across all environments.
- This copies the smart-answers "Heroku" banner to tell people that they
  should look at Production.

Before:

<img width="1362" alt="Screenshot 2020-02-20 at 12 58 13" src="https://user-images.githubusercontent.com/355033/74936205-a4737b00-53e1-11ea-8b15-b925658af62d.png">

After:

<img width="1270" alt="Screenshot 2020-02-20 at 13 04 49" src="https://user-images.githubusercontent.com/355033/74936210-a89f9880-53e1-11ea-887d-cba921bba50d.png">
