### PR TITLE
Delete `govuk-lint` from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :test, :development do
   gem "capybara", "~> 3"
   gem "database_cleaner", "~> 1"
   gem "factory_bot_rails"
-  gem "govuk-lint"
   gem "minitest", "~> 5"
   gem "mocha", "~> 1", require: false
   gem "poltergeist", "~> 1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,11 +107,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -301,8 +296,6 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     shoulda-context (1.2.2)
@@ -361,7 +354,6 @@ DEPENDENCIES
   factory_bot_rails
   friendly_id (~> 5)
   gds-sso (~> 14)
-  govuk-lint
   govuk_admin_template (~> 6)
   govuk_app_config
   govuk_publishing_components


### PR DESCRIPTION
- It was replaced by `rubocop-govuk` last year, but never actually removed: https://github.com/alphagov/release/pull/521.
- This skewed our stats on the scale of the problem of apps not migrated to `rubocop-govuk` yet.