### PR TITLE
Add API endpoint for Applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.2"
 
+gem "active_model_serializers", "~> 0.10.0"
 gem "friendly_id", "~> 5"
 gem "mysql2", "~> 0.4"
 gem "octicons_helper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.4.3)
       activesupport (= 5.2.4.3)
       globalid (>= 0.3.6)
@@ -46,7 +51,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.7.6)
       execjs
     better_errors (2.7.1)
       coderay (>= 1.0.0)
@@ -66,6 +71,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     chartkick (3.3.1)
     cliver (0.3.2)
     coderay (1.1.2)
@@ -117,7 +124,7 @@ GEM
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.46.0)
+    govuk_publishing_components (21.47.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -137,6 +144,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jsonapi-renderer (0.2.2)
     jwt (2.2.1)
     kgio (2.11.3)
     kramdown (2.2.1)
@@ -166,7 +174,7 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    mysql2 (0.4.10)
+    mysql2 (0.5.3)
     netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -283,8 +291,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
+    sass-rails (5.1.0)
+      railties (>= 5.2.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -300,7 +308,7 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+    simplecov-html (0.12.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
     sprockets (3.7.2)
@@ -344,6 +352,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   better_errors (~> 2)
   binding_of_caller (~> 0.8)
   capybara (~> 3)
@@ -375,4 +384,4 @@ DEPENDENCIES
   webmock (~> 3)
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,6 @@
+class Api::ApplicationController < ActionController::API
+  include ActionController::Helpers
+  include GDS::SSO::ControllerMethods
+
+  before_action :authenticate_user!
+end

--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -1,0 +1,7 @@
+class Api::ApplicationsController < Api::ApplicationController
+  def show
+    @application = Application.friendly.find(params[:id])
+
+    render json: @application
+  end
+end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,6 @@
+class ApplicationSerializer < ActiveModel::Serializer
+  attributes :name, :shortname, :archived, :deploy_freeze
+  attribute :status_notes, key: :notes
+  attribute :repo_url, key: :repository_url
+  attribute :on_aws, key: :hosted_on_aws
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 ReleaseApp::Application.routes.draw do
+  namespace :api, defaults: { format: :json } do
+    resources :applications, only: [:show]
+  end
+
   resources :applications do
     collection do
       get "archived", to: "applications#archived"

--- a/doc/README_FOR_APP
+++ b/doc/README_FOR_APP
@@ -1,2 +1,0 @@
-Use this README file to introduce your application and point to useful places in the API for learning more.
-Run "rake doc:app" to generate API documentation for your models, controllers, helpers, and libraries.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,39 @@
+# Release API
+
+The Release app exposes information about GOV.UK applications a RESTful API.
+
+Current implemented endpoints are oulined below:
+
+
+## Show Application: GET `/api/application/:id`
+
+Get information about a specific application where `:id` is the application shortname.
+
+### Success Response
+
+Code: `200 OK`
+
+Examples:
+```json
+{
+   "name": "Smart Answers",
+   "shortname": "smartanswers",
+   "archived": false,
+   "deploy_freeze": true,
+   "notes": "",
+   "repository_url": "https://github.com/alphagov/smart-answers",
+   "hosted_on_aws": true
+}
+```
+
+
+### Error Responses
+
+Code: `404 Resource not found`
+
+```json
+{
+   "status": 404,
+   "error": "Not found"
+}
+```

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Application #{n}" }
     sequence(:repo) { |n| "alphagov/application-#{n}" }
     domain { "mygithub.tld" }
+    status_notes { "" }
   end
 
   factory :deployment do

--- a/test/functional/api/applications_controller_test.rb
+++ b/test/functional/api/applications_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Api::ApplicationsControllerTest < ActionController::TestCase
+  setup do
+    login_as_stub_user
+  end
+
+  context "GET show" do
+    setup do
+      @app = FactoryBot.create(:application)
+    end
+
+    should "return a succsessful response" do
+      get :show, params: { id: @app.id }
+      body = JSON.parse(response.body)
+
+      assert_response :success
+      assert_equal "application/json", response.content_type
+
+      assert_equal "Application 1", body["name"]
+      assert_equal "application-1", body["shortname"]
+      assert_equal "", body["status_notes"]
+      assert_equal false, body["archived"]
+      assert_equal false, body["on_aws"]
+    end
+  end
+end

--- a/test/functional/api/applications_controller_test.rb
+++ b/test/functional/api/applications_controller_test.rb
@@ -7,7 +7,7 @@ class Api::ApplicationsControllerTest < ActionController::TestCase
 
   context "GET show" do
     setup do
-      @app = FactoryBot.create(:application)
+      @app = FactoryBot.create(:application, name: "Application 1", repo: "alphagov/application-1")
     end
 
     should "return a succsessful response" do
@@ -19,9 +19,11 @@ class Api::ApplicationsControllerTest < ActionController::TestCase
 
       assert_equal "Application 1", body["name"]
       assert_equal "application-1", body["shortname"]
-      assert_equal "", body["status_notes"]
+      assert_equal "", body["notes"]
       assert_equal false, body["archived"]
-      assert_equal false, body["on_aws"]
+      assert_equal false, body["deploy_freeze"]
+      assert_equal false, body["hosted_on_aws"]
+      assert_equal "https://mygithub.tld/alphagov/application-1", body["repository_url"]
     end
   end
 end


### PR DESCRIPTION
This PR adds an endpoint for GET requests at `/api/applications/:id`. The response is a JSON formatted object with the following attributes:
```json
{
   "name": "Smart answers",
   "shortname": "smartanswers",
   "archived ":false,
   "notes": "",
   "repository_url": "https://github.com/alphagov/smart-answers",
   "hosted_on_aws": true,
   "deploy_freeze": true
}
```

Here we are creating a separate namespace `api` to contain both the routes and the code. Authentication can be done by specifying the `Authorization: <Bearer Token>` header, with a key generated from Signon.

https://trello.com/c/aKknOBkY/149-expose-a-json-format-response-of-application-id-in-release