### PR TITLE
Add deploy freeze attribute

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,15 +30,22 @@ $govuk-typography-use-rem: false;
 }
 
 .release__badge {
-  @include govuk-font(16, $weight: "bold");
+  @include govuk-font(14, $weight: "bold");
   background-color:  govuk-colour("light-blue");
   padding: 3px 5px;
   border-radius: 20px;
   color: govuk-colour("white");
+  white-space: nowrap;
+  display: inline-block;
+  margin-bottom: govuk-spacing(1);
 }
 
-.release__badge--aws {
+.release__badge--orange {
   background-color: govuk-colour("orange");
+}
+
+.release__badge--red {
+  background-color: govuk-colour("red");
 }
 
 .release__view-diff {

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -146,6 +146,7 @@ private
       :status_notes,
       :task,
       :on_aws,
+      :deploy_freeze,
     )
   end
 

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -25,7 +25,7 @@
         <%= t.row do %>
           <% application_name = capture do %>
             <%= link_to application.name, application, class: "govuk-link release__application-link", data: { "filter-applications-link": "" } %> </br>
-            <%= render partial: "provider_badge", locals: { application: application } %>
+            <%= render partial: "badges", locals: { application: application } %>
           <% end %>
 
           <% application_notes = capture do %>

--- a/app/views/applications/_badges.html.erb
+++ b/app/views/applications/_badges.html.erb
@@ -1,0 +1,9 @@
+<% if application.on_aws? %>
+  <span class="release__badge release__badge--orange">AWS</span>
+<% else %>
+  <span class="release__badge">Carrenza</span>
+<% end %>
+
+<% if application.deploy_freeze? %>
+  <span class="release__badge release__badge--red">Do not deploy</span>
+<% end %>

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -67,6 +67,18 @@
     ]
   } %>
 
+  <input type="hidden" name="application[deloy_freeze]" value="0" />
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "application[deploy_freeze]",
+    items: [
+      {
+        label: "Freeze deployements?",
+        value: "1",
+        checked: @application.deploy_freeze?
+      }
+    ]
+  } %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: "Update application",
     name: "application[commit]",

--- a/app/views/applications/_provider_badge.html.erb
+++ b/app/views/applications/_provider_badge.html.erb
@@ -1,5 +1,0 @@
-<% if application.on_aws? %>
-  <span class="release__badge release__badge--aws">AWS</span>
-<% else %>
-  <span class="release__badge">Carrenza</span>
-<% end %>

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -19,7 +19,7 @@
     },
     margin_bottom: 2
   } %>
-  <%= render partial: "provider_badge", locals: { application: @application } %>
+  <%= render partial: "badges", locals: { application: @application } %>
 </div>
 
 <%= render 'status_notes', application: @application %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -15,7 +15,7 @@
     context: @application.shortname,
     margin_bottom: 2
   } %>
-  <%= render partial: "provider_badge", locals: { application: @application } %>
+  <%= render partial: "badges", locals: { application: @application } %>
 </div>
 
 <%= render "components/tabs", {

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -14,7 +14,7 @@
     context: @application.shortname,
     margin_bottom: 2
   } %>
-  <%= render partial: "provider_badge", locals: { application: @application } %>
+  <%= render partial: "badges", locals: { application: @application } %>
 </div>
 
 <%= render "components/tabs", {

--- a/app/views/applications/stats.html.erb
+++ b/app/views/applications/stats.html.erb
@@ -15,7 +15,7 @@
     context: @application.shortname,
     margin_bottom: 2
   } %>
-  <%= render partial: "provider_badge", locals: { application: @application } %>
+  <%= render partial: "badges", locals: { application: @application } %>
 </div>
 
 <%= render "components/tabs", {

--- a/app/views/deployments/index.html.erb
+++ b/app/views/deployments/index.html.erb
@@ -15,7 +15,7 @@
     context: @application.shortname,
     margin_bottom: 2
   } %>
-  <%= render partial: "applications/provider_badge", locals: { application: @application } %>
+  <%= render partial: "applications/badges", locals: { application: @application } %>
 </div>
 
 <%= render "components/tabs", {

--- a/db/migrate/20200512101702_add_deploy_freeze_to_applications.rb
+++ b/db/migrate/20200512101702_add_deploy_freeze_to_applications.rb
@@ -1,0 +1,5 @@
+class AddDeployFreezeToApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applications, :deploy_freeze, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_07_105232) do
+ActiveRecord::Schema.define(version: 2020_05_12_101702) do
 
   create_table "applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2019_10_07_105232) do
     t.string "domain"
     t.boolean "archived", default: false, null: false
     t.boolean "on_aws", default: false, null: false
+    t.boolean "deploy_freeze", default: false, null: false
     t.index ["name"], name: "index_applications_on_name", unique: true
     t.index ["repo"], name: "index_applications_on_repo"
     t.index ["shortname"], name: "index_applications_on_shortname"

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -95,6 +95,16 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select ".release__badge", "AWS"
     end
 
+    should "show the deployment freeze badge" do
+      get :show, params: { id: @app.id }
+      assert_select ".release__badge", { text: "Do not deploy", count: 0 }
+
+      @app.update(deploy_freeze: true)
+
+      get :show, params: { id: @app.id }
+      assert_select ".release__badge", "Do not deploy"
+    end
+
     should "should include status notes as a warning" do
       @app.update(status_notes: "Do not deploy this without talking to core team first!")
       get :show, params: { id: @app.id }

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -193,10 +193,11 @@ class ApplicationsControllerTest < ActionController::TestCase
     end
 
     should "update the application" do
-      put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true } }
+      put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true, deploy_freeze: true } }
       @app.reload
       assert_equal "new name", @app.name
-      assert_equal @app.on_aws?, true
+      assert_equal true, @app.on_aws?
+      assert_equal true, @app.deploy_freeze?
     end
 
     context "invalid request" do

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -73,17 +73,21 @@ class ApplicationTest < ActiveSupport::TestCase
     end
 
     should "default to not being archived" do
-      @atts.delete :archived
       application = Application.new(@atts)
 
       assert_equal false, application.archived
     end
 
     should "default to not being on AWS" do
-      @atts.delete :on_aws
       application = Application.new(@atts)
 
       assert_equal false, application.on_aws?
+    end
+
+    should "default to not be in deploy freeze" do
+      application = Application.new(@atts)
+
+      assert_equal false, application.deploy_freeze?
     end
 
     should "be invalid with a name that is too long" do


### PR DESCRIPTION
Add deployment freeze attribute for Applications. This is to enable the Release app to be an authoritative place to declare deploy freezes. In this PR we add:
- The `deploy_freeze` attribute for Application
- Ability to toggle this attribute under the "Edit" page
- A badge to be displayed when application is under a deployment freeze.

![image](https://user-images.githubusercontent.com/11051676/81701512-0502d900-9462-11ea-9cb2-0eabf67a0eb8.png)
![image](https://user-images.githubusercontent.com/11051676/81701560-1c41c680-9462-11ea-84ad-5d681a80c2ca.png)

This supersedes #618 (closed because it was including old commit already in master - maybe GitHub bug? Maybe just me not using git properly)

https://trello.com/c/q01nLzAx/148-add-a-deploy-freeze-flag-setting-for-each-app-in-release