### PR TITLE
Fix bug in turning off deploy freeze

### DIFF
--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -67,7 +67,7 @@
     ]
   } %>
 
-  <input type="hidden" name="application[deloy_freeze]" value="0" />
+  <input type="hidden" name="application[deploy_freeze]" value="0" />
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "application[deploy_freeze]",
     items: [


### PR DESCRIPTION
The attribute was misspelt in the form prevent the deploy freeze to be turned off.