### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,9 @@ require File.expand_path("config/application", __dir__)
 
 ReleaseApp::Application.load_tasks
 
-task default: [:test]
+desc "Lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
+end
+
+task default: %i[test lint]


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)