### PR TITLE
Include production-aws deployments in stats charts

### DIFF
--- a/app/models/deployment_stats.rb
+++ b/app/models/deployment_stats.rb
@@ -1,8 +1,8 @@
 class DeploymentStats
   attr_reader :initial_scope
 
-  def initialize(initial_scope = nil)
-    @initial_scope = initial_scope || Deployment
+  def initialize(initial_scope = Deployment)
+    @initial_scope = initial_scope
   end
 
   def per_month
@@ -22,7 +22,7 @@ private
 
   def production_deploys
     @production_deploys ||= initial_scope
-      .where(environment: "production")
+      .where(environment: %w[production production-aws])
       .joins(:application)
       .order("deployments.created_at ASC")
   end

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -16,10 +16,11 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "production")
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
 
       expected = {
         "2018-01" => 1,
-        "2018-02" => 2,
+        "2018-02" => 3,
       }
 
       assert_equal(expected, DeploymentStats.new.per_month)
@@ -38,12 +39,14 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       FactoryBot.create(:deployment, created_at: "2016-01-01", application: app, environment: "production")
       FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
       FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
+
       # Do include deploys from this year
       FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
 
       expected = {
         2016 => 1,
-        2017 => 2,
+        2017 => 3,
         Time.zone.now.year => 1,
       }
 
@@ -62,7 +65,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production")
 
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
 
       expected = {
         "2018-02" => 2,


### PR DESCRIPTION
Currently the charts say there were 1953 deployments in 2019, but this is only for the Production Carrenza environment. Including AWS Production deployments there were 4399 deploys last year.