### PR TITLE
Remove domain field since everything we have is on GitHub.com now

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -143,7 +143,6 @@ private
   def application_params
     params.require(:application).permit(
       :archived,
-      :domain,
       :id,
       :name,
       :repo,

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -64,7 +64,7 @@ private
 
     case existing_apps.length
     when 0
-      Application.create!(name: normalize_app_name(repo_path), repo: repo_path, domain: domain)
+      Application.create!(name: normalize_app_name(repo_path), repo: repo_path)
     when 1
       existing_apps[0]
     else
@@ -80,7 +80,7 @@ private
     existing_apps = Application.where(name: normalize_app_name(params[:application_name]))
 
     if existing_apps.length.zero?
-      Application.create!(name: normalize_app_name(params[:application_name]), repo: repo_path, domain: domain)
+      Application.create!(name: normalize_app_name(params[:application_name]), repo: repo_path)
     elsif existing_apps.length == 1
       existing_apps[0]
     end
@@ -99,11 +99,6 @@ private
   def normalize_app_name(unnormalized_app_name)
     normalized_app_name = unnormalized_app_name.split("/")[-1].tr("-", " ").humanize.titlecase
     normalized_app_name.gsub(/\bApi\b/, "API")
-  end
-
-  def domain
-    # Deployments created from push notifications will default to github.com
-    "github.com"
   end
 
   def push_notification?

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,9 +5,8 @@ class Application < ApplicationRecord
 
   validates :name, presence: { message: "is required" }
   validates :repo, presence: { message: "is required" }
-  validates :domain, presence: { message: "is required" }
 
-  validates :name, :repo, :domain, :status_notes, :shortname, length: { maximum: 255 }
+  validates :name, :repo, :status_notes, :shortname, length: { maximum: 255 }
 
   validates :repo, format: { with: /\A[^\s\/]+\/[^\s\/]+\Z/i }
 
@@ -52,15 +51,15 @@ class Application < ApplicationRecord
   end
 
   def repo_url
-    "https://#{domain}/#{repo}"
+    "https://github.com/#{repo}"
   end
 
   def repo_compare_url(from, to)
-    "https://#{domain}/#{repo}/compare/#{from}...#{to}"
+    "https://github.com/#{repo}/compare/#{from}...#{to}"
   end
 
   def repo_tag_url(tag)
-    "https://#{domain}/#{repo}/releases/tag/#{tag}"
+    "https://github.com/#{repo}/releases/tag/#{tag}"
   end
 
   def production_and_staging_environments

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -18,15 +18,6 @@
 
   <%= render "govuk_publishing_components/components/input", {
     label: {
-      text: "GitHub domain"
-    },
-    name: "application[domain]",
-    hint: "Example: github.com",
-    value: @application.domain
-  } %>
-
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
       text: "Short name"
     },
     name: "application[shortname]",

--- a/db/migrate/20200805150707_remove_github_domain_column_from_application.rb
+++ b/db/migrate/20200805150707_remove_github_domain_column_from_application.rb
@@ -1,0 +1,5 @@
+class RemoveGithubDomainColumnFromApplication < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :applications, :domain, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_12_101702) do
+ActiveRecord::Schema.define(version: 2020_08_05_150707) do
 
   create_table "applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name"
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 2020_05_12_101702) do
     t.datetime "updated_at", null: false
     t.string "status_notes"
     t.string "shortname"
-    t.string "domain"
     t.boolean "archived", default: false, null: false
     t.boolean "on_aws", default: false, null: false
     t.boolean "deploy_freeze", default: false, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,6 @@ applications = [
   { name: "Licence finder",                         repo: "alphagov/licence-finder", shortname: "licencefinder" },
   { name: "Licensify",                              repo: "alphagov/licensify" },
   { name: "Publisher",                              repo: "alphagov/publisher" },
-  { name: "Puppet",                                 repo: "gds/puppet", domain: "github.gds" },
   { name: "Rummager",                               repo: "alphagov/rummager" },
   { name: "Signon",                                 repo: "alphagov/signon" },
   { name: "Smart answers",                          repo: "alphagov/smart-answers", shortname: "smartanswers" },
@@ -23,10 +22,9 @@ applications = [
 ]
 
 applications.each do |application_hash|
-  app_defaults = { domain: "github.com" }
   next if Application.find_by(name: application_hash[:name]).present?
 
-  Application.create!(app_defaults.merge(application_hash))
+  Application.create!(application_hash)
 end
 
 # Create a dummy user

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :application do
     sequence(:name) { |n| "Application #{n}" }
     sequence(:repo) { |n| "alphagov/application-#{n}" }
-    domain { "mygithub.tld" }
     status_notes { "" }
   end
 

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -25,12 +25,12 @@ class ApplicationsControllerTest < ActionController::TestCase
 
     should "show the latest deploy to an environment" do
       get :index
-      assert_select ".gem-c-table .govuk-table__body .govuk-link[href='https://mygithub.tld/user/app1/tree/release_x']", "release_x"
+      assert_select ".gem-c-table .govuk-table__body .govuk-link[href='https://github.com/user/app1/tree/release_x']", "release_x"
     end
 
     should "provide a link to compare with master" do
       get :index
-      assert_select ".gem-c-table .govuk-table__body .govuk-link[href=?]", "https://mygithub.tld/user/app1/compare/release_x...master"
+      assert_select ".gem-c-table .govuk-table__body .govuk-link[href=?]", "https://github.com/user/app1/compare/release_x...master"
     end
   end
 
@@ -49,7 +49,6 @@ class ApplicationsControllerTest < ActionController::TestCase
                application: {
                  name: "My First App",
                  repo: "org/my_first_app",
-                 domain: "github.baz",
                },
              }
       end
@@ -60,7 +59,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         post :create, params: { application: { name: "", repo: "org/my_first_app" } }
         assert_select ".gem-c-error-alert"
         assert_select ".gem-c-error-summary__title", text: "There was a problem creating the new application"
-        assert_select ".gem-c-error-summary__body", text: "Name is required, Domain is required"
+        assert_select ".gem-c-error-summary__body", text: "Name is required"
       end
 
       should "rerender the form" do
@@ -159,7 +158,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         @app = FactoryBot.create(:application, name: "Application 1", repo: "alphagov/application-1")
       end
 
-      should "return a succsessful response" do
+      should "return a successful response" do
         get :show, params: { id: @app.id }, format: :json
         body = JSON.parse(response.body)
 
@@ -172,7 +171,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         assert_equal false, body["archived"]
         assert_equal false, body["deploy_freeze"]
         assert_equal false, body["hosted_on_aws"]
-        assert_equal "https://mygithub.tld/alphagov/application-1", body["repository_url"]
+        assert_equal "https://github.com/alphagov/application-1", body["repository_url"]
       end
     end
 

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -8,7 +8,6 @@ class ApplicationTest < ActiveSupport::TestCase
       @atts = {
         name: "Tron-o-matic",
         repo: "alphagov/tron-o-matic",
-        domain: "github.foo",
       }
     end
 
@@ -69,7 +68,7 @@ class ApplicationTest < ActiveSupport::TestCase
     should "know its location on the internet" do
       application = Application.new(@atts)
 
-      assert_equal "https://github.foo/alphagov/tron-o-matic", application.repo_url
+      assert_equal "https://github.com/alphagov/tron-o-matic", application.repo_url
     end
 
     should "default to not being archived" do
@@ -92,12 +91,6 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "be invalid with a name that is too long" do
       application = Application.new(@atts.merge(name: ("a" * 256)))
-
-      assert_not application.valid?
-    end
-
-    should "be invalid with a domain that is too long" do
-      application = Application.new(@atts.merge(domain: ("gith" + ("u" * 247) + "b.com")))
 
       assert_not application.valid?
     end


### PR DESCRIPTION
- A `domain` field was added to each application in ec0f156a in 2013. It defaulted to `GitHub.com`, but repo names beginning with `gds` were presumed to be on our GitHub Enterprise Server instance. In Septemper 2018, our GitHub Enterprise Server instance (`github.gds`, later `github.digital.cabinet-office.gov.uk`) was shut down after a migration of everything on it to GitHub.com.
- I found this field after editing a note in the Release app, and thought I'd tidy up by removing the legacy code as it's irrelevant now that everything is on GitHub.com.
