### PR TITLE
Clarify the behaviour of a deploy freeze

### DIFF
--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -74,7 +74,8 @@
       {
         label: "Freeze deployments?",
         value: "1",
-        checked: @application.deploy_freeze?
+        checked: @application.deploy_freeze?,
+        hint: "Disables automatic deployments. Our deploy jobs will query the value of this flag in the API and abort if it is set. Manual deploy job builds will continue to work."
       }
     ]
   } %>

--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -5,5 +5,5 @@
 <% end %>
 
 <% if application.deploy_freeze? %>
-  <span class="release__badge release__badge--red">Do not deploy</span>
+  <span class="release__badge release__badge--red">Automatic deployments disabled</span>
 <% end %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -100,12 +100,12 @@ class ApplicationsControllerTest < ActionController::TestCase
 
     should "show the deployment freeze badge" do
       get :show, params: { id: @app.id }
-      assert_select ".release__badge", { text: "Do not deploy", count: 0 }
+      assert_select ".release__badge", { text: "Automatic deployments disabled", count: 0 }
 
       @app.update!(deploy_freeze: true)
 
       get :show, params: { id: @app.id }
-      assert_select ".release__badge", "Do not deploy"
+      assert_select ".release__badge", "Automatic deployments disabled"
     end
 
     should "should include status notes as a warning" do


### PR DESCRIPTION
https://trello.com/c/9HyK1pht/174-consolidate-cd-retro-outcomes-into-cards-or-the-draft-rfc

While the naming of this flag is still accurate, the "Do not deploy"
badge was imprecise. Since we generally write an explanatory note for
a deploy freeze, this renames the badge to complement the note by
calling out the behavioural change, together with a hint about this
for someone changing the setting.

## Screenshots

<img width="1005" alt="Screenshot 2020-08-06 at 10 55 06" src="https://user-images.githubusercontent.com/9029009/89518812-5b6a8400-d7d3-11ea-93a6-fc0f1e78c16d.png">
<img width="461" alt="Screenshot 2020-08-06 at 10 55 00" src="https://user-images.githubusercontent.com/9029009/89518813-5c031a80-d7d3-11ea-9d71-5724b7b1ae88.png">
<img width="399" alt="Screenshot 2020-08-06 at 10 54 22" src="https://user-images.githubusercontent.com/9029009/89518814-5c031a80-d7d3-11ea-90ea-61c75f9adb2d.png">
