### PR TITLE
Fix asset pipeline with libsass

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,11 @@ module ReleaseApp
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = "London"
+
+    # Using a sass css compressor causes a scss file to be processed twice
+    # (once to build, once to compress) which breaks the usage of "unquote"
+    # to use CSS that has same function names as SCSS such as max.
+    # https://github.com/alphagov/govuk-frontend/issues/1350
+    config.assets.css_compressor = nil
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,10 +35,4 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
-
-  # Using a sass css compressor causes a scss file to be processed twice
-  # (once to build, once to compress) which breaks the usage of "unquote"
-  # to use CSS that has same function names as SCSS such as max.
-  # https://github.com/alphagov/govuk-frontend/issues/1350
-  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
* Fixes commit of accidently putting the config in environments/test.rb instead of application.rb

Using a sass css compressor causes a scss file to be processed twice
(once to build, once to compress) which breaks the usage of "unquote"
to use CSS that has same function names as SCSS such as max.

alphagov/govuk-frontend#1350