### PR TITLE
Re-combine the deploy url helpers

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -24,15 +24,10 @@ module UrlHelper
     "#{environment}.publishing.service.gov.uk"
   end
 
-  def jenkins_deploy_app_url(application, release_tag, environment)
+  def jenkins_deploy_url(application, release_tag, environment)
     suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    job_name = application.shortname == "puppet" ? "Deploy_Puppet" : "Deploy_App"
     escaped_release_tag = CGI.escape(release_tag)
-    "https://deploy.#{suffix}/job/Deploy_App/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe
-  end
-
-  def jenkins_deploy_puppet_url(release_tag, environment, aws:)
-    suffix = govuk_domain_suffix(environment, on_aws: aws)
-    escaped_release_tag = CGI.escape(release_tag)
-    "https://deploy.#{suffix}/job/Deploy_Puppet/parambuild?TAG=#{escaped_release_tag}".html_safe
+    "https://deploy.#{suffix}/job/#{job_name}/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe
   end
 end

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -87,7 +87,7 @@
     </p>
     <%= render "govuk_publishing_components/components/button", {
       text: "Deploy to Staging",
-      href: jenkins_deploy_app_url(@application, @release_tag, "staging"),
+      href: jenkins_deploy_url(@application, @release_tag, "staging"),
       target: "_blank",
       margin_bottom: true
     } %>
@@ -109,7 +109,7 @@
     </p>
     <%= render "govuk_publishing_components/components/button", {
       text: "Deploy to Production",
-      href: jenkins_deploy_app_url(@application, @release_tag, "production"),
+      href: jenkins_deploy_url(@application, @release_tag, "production"),
       target: "_blank",
       destructive: true,
       margin_bottom: true


### PR DESCRIPTION
Now that the same view code is used for Puppet as well as apps.