### PR TITLE
Always print code coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :test, :development do
   gem "rubocop-govuk"
   gem "shoulda-context", require: false
   gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
   gem "timecop"
   gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,8 +295,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -362,7 +360,6 @@ DEPENDENCIES
   sass-rails
   shoulda-context
   simplecov
-  simplecov-rcov
   timecop
   uglifier
   webmock

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,4 @@
 require "simplecov"
-require "simplecov-rcov"
-
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.start "rails"
 
 ENV["RAILS_ENV"] = "test"


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Note that the RCov formatter is optional, and it's still possible
to see a web page of the detailed coverage.