### PR TITLE
Fix Smokey URL for Integration environment

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -18,10 +18,15 @@ module UrlHelper
   end
 
   def govuk_domain_suffix(environment, on_aws:)
-    return "blue.#{environment}.govuk.digital" if on_aws
-    return "publishing.service.gov.uk" if environment == "production"
-
-    "#{environment}.publishing.service.gov.uk"
+    if environment == "integration"
+      "integration.publishing.service.gov.uk"
+    elsif on_aws
+      "blue.#{environment}.govuk.digital"
+    elsif environment == "production"
+      "publishing.service.gov.uk"
+    else
+      "#{environment}.publishing.service.gov.uk"
+    end
   end
 
   def jenkins_deploy_url(application, release_tag, environment)


### PR DESCRIPTION
Our domain suffix rules aren't as clear cut as perhaps originally
intended when this code was written. Integration doesn't use the
`govuk.digital` domain. Consequently, the 'Integration smokey'
link has not worked for a long time, and developers have to then
navigate the Jenkins UI to find it.

This PR fixes that, and restructures the `govuk_domain_suffix`
to remove outdated code and be easier to read.

To clarify, the Release app:

- Currently links to `https://deploy.blue.integration.govuk.digital/job/Smokey`
- ...which redirects to `https://deploy.integration.publishing.service.gov.uk/`
- Actual URL should be `https://deploy.integration.publishing.service.gov.uk/job/Smokey/`