### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,5 @@ library("govuk")
 REPOSITORY = 'release'
 
 node {
-  govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    sassLint: false,
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82