### PR TITLE
Configurable default branch

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -146,6 +146,7 @@ private
       :id,
       :name,
       :repo,
+      :default_branch,
       :shortname,
       :status_notes,
       :task,

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -40,7 +40,7 @@ class ApplicationsController < ApplicationController
           comparison = Services.github.compare(
             @application.repo,
             @production_deploy.version,
-            "master",
+            @application.default_branch,
           )
           # The `compare` API shows commits in forward chronological order
           @commits = comparison.commits.reverse + [comparison.base_commit]

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -13,8 +13,8 @@ module UrlHelper
     link_to(git_ref.truncate(15), "#{app.repo_url}/tree/#{git_ref}", target: "_blank", rel: "noopener", class: "govuk-link")
   end
 
-  def github_compare_to_master(application, deploy)
-    "#{application.repo_url}/compare/#{deploy.version}...master"
+  def github_compare_to_default(application, deploy)
+    "#{application.repo_url}/compare/#{deploy.version}...#{application.default_branch}"
   end
 
   def govuk_domain_suffix(environment, on_aws:)

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -12,6 +12,10 @@ class Application < ApplicationRecord
 
   validates :name, uniqueness: { case_sensitive: true }
 
+  validates :default_branch, presence: true
+
+  enum default_branch: { master: "master", main: "main" }, _prefix: true
+
   has_many :deployments, dependent: :destroy
 
   default_scope { order("name ASC") }

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -2,5 +2,6 @@ class ApplicationSerializer < ActiveModel::Serializer
   attributes :name, :shortname, :archived, :deploy_freeze
   attribute :status_notes, key: :notes
   attribute :repo_url, key: :repository_url
+  attribute :default_branch, key: :repository_default_branch
   attribute :on_aws, key: :hosted_on_aws
 end

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -50,8 +50,8 @@
               <% if latest_deploy %>
                 <p class="govuk-body-s govuk-!-margin-bottom-1"><%= github_tag_link_to(application, latest_deploy.version) %></p>
                 <p class="govuk-body-s govuk-!-margin-bottom-1"><%= human_datetime(latest_deploy.created_at) %></p>
-                <%= link_to(github_compare_to_master(application, latest_deploy), target: "_blank", class: "compare govuk-link govuk-body-s") do %>
-                  <%= octicon "git-compare", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-label": "Compare to master" %>
+                <%= link_to(github_compare_to_default(application, latest_deploy), target: "_blank", class: "compare govuk-link govuk-body-s") do %>
+                  <%= octicon "git-compare", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-label": "Compare to #{application.default_branch}" %>
                 <% end %>
               <% else %>
                 <p class="govuk-body-s">N/A</p>

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -16,6 +16,19 @@
     value: @application.repo
   } %>
 
+  <%= render "govuk_publishing_components/components/select", {
+    id: "default_branch",
+    label: "GitHub repository default branch",
+    name: "application[default_branch]",
+    options: Application.default_branches.map do |(id, label)|
+      {
+        text: label,
+        value: id,
+        selected: @application.default_branch == label,
+      }
+    end
+  } %>
+
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "Short name"

--- a/db/migrate/20210224004602_add_default_branch_to_application.rb
+++ b/db/migrate/20210224004602_add_default_branch_to_application.rb
@@ -1,0 +1,5 @@
+class AddDefaultBranchToApplication < ActiveRecord::Migration[6.0]
+  def change
+    add_column :applications, :default_branch, :string, default: "master", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_150707) do
+ActiveRecord::Schema.define(version: 2021_02_24_004602) do
 
   create_table "applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_08_05_150707) do
     t.boolean "archived", default: false, null: false
     t.boolean "on_aws", default: false, null: false
     t.boolean "deploy_freeze", default: false, null: false
+    t.string "default_branch", default: "master", null: false
     t.index ["name"], name: "index_applications_on_name", unique: true
     t.index ["repo"], name: "index_applications_on_repo"
     t.index ["shortname"], name: "index_applications_on_shortname"

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -7,7 +7,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "GET index" do
     setup do
-      @app1 = FactoryBot.create(:application, name: "app1", repo: "user/app1")
+      @app1 = FactoryBot.create(:application, name: "app1", repo: "user/app1", default_branch: "main")
       @app2 = FactoryBot.create(:application, name: "app2", repo: "user/app2")
       @app3 = FactoryBot.create(:application, name: "app3", repo: "user/app3", archived: true)
       @deploy1 = FactoryBot.create(
@@ -28,9 +28,9 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select ".gem-c-table .govuk-table__body .govuk-link[href='https://github.com/user/app1/tree/release_x']", "release_x"
     end
 
-    should "provide a link to compare with master" do
+    should "provide a link to compare with default branch" do
       get :index
-      assert_select ".gem-c-table .govuk-table__body .govuk-link[href=?]", "https://github.com/user/app1/compare/release_x...master"
+      assert_select ".gem-c-table .govuk-table__body .govuk-link[href=?]", "https://github.com/user/app1/compare/release_x...main"
     end
   end
 
@@ -121,7 +121,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         @second_commit = stub_commit
         @base_commit = stub_commit
         Octokit::Client.any_instance.stubs(:compare)
-          .with(@app.repo, version, "master")
+          .with(@app.repo, version, @app.default_branch)
           .returns(stub(
                      "comparison",
                      commits: [@first_commit, @second_commit],


### PR DESCRIPTION
Trello: https://trello.com/c/JPM4Qqro/208-update-release-app-to-support-apps-without-a-master-branch

This adds an attribute to an application of the value of the default branch. This is defaulted to master. This can be changed to "main" for apps that have been migrated to a "main" default branch.

![Screenshot 2021-02-24 at 14 51 02](https://user-images.githubusercontent.com/282717/109018408-00857500-76b0-11eb-958d-277b44de717b.png)

I did consider whether this information could be determined on the fly with GitHub however this app doesn't communicate with GitHub to render key pages like: https://release.publishing.service.gov.uk/applications so needs to be stored in the DB for backwards compatibility. (I did discover you can do something of a hack with a URL like https://github.com/alphagov/maslow/compare/release_598...HEAD - however this can be broken by the unlikely event of having a branch called HEAD - which I accidentally managed to create while testing 🤦 ).

This doesn't fix that applications raise a 500 when you view commits and the default branch has been changed as per visiting: https://release.publishing.service.gov.uk/applications/maslow. I did spend a while looking into that and I think this is caused by a problem with Octokit not turning 404's into errors as I'd expect https://github.com/alphagov/release/blob/dd79d04b226803a0926c9382219afd756f08b6cc/app/controllers/applications_controller.rb#L56-L58 to be called however the code doesn't produce an exception.

For example:

```
irb(main):001:0> Services.github.compare("alphagov/maslow", "ca986f4", "master")
=>
{:message=>"Not Found",
 :documentation_url=>
  "https://docs.github.com/rest/reference/repos#compare-two-commits"}
```

So this seems out of the scope of this change.