### PR TITLE
Bump octokit to 4.20.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     octicons_helper (9.6.0)
       octicons (= 9.6.0)
       rails
-    octokit (4.18.0)
+    octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     omniauth (1.9.1)
@@ -210,7 +210,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)


### PR DESCRIPTION
Trello: https://trello.com/c/JPM4Qqro/208-update-release-app-to-support-apps-without-a-master-branch

This fixes an issue where communication with GitHub no longer resulted
in exceptions being raised on the event of an error [1].

[1]: https://github.com/octokit/octokit.rb/pull/1316

Before:

![Screenshot 2021-02-25 at 09 23 43](https://user-images.githubusercontent.com/282717/109132575-e4cfac80-774b-11eb-8b8d-8f1ff304eaee.png)

After:

![Screenshot 2021-02-25 at 09 27 37](https://user-images.githubusercontent.com/282717/109132592-ea2cf700-774b-11eb-9166-ce8cab2f1a2e.png)
