### PR TITLE
Fix a variety of flash message and form problems

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -93,34 +93,18 @@ class ApplicationsController < ApplicationController
   def create
     @application = Application.new(application_params)
 
-    if @application.valid? && @application.save
-
-      flash.now[:notice] = { message: "Successfully created new application" }
-
-      render action: "show"
+    if @application.save
+      redirect_to @application, notice: "Successfully created new application"
     else
-      errors = @application.errors.full_messages
-
-      error_string = errors.join(", ")
-
-      flash.now[:error] = { message: "There was a problem creating the new application", description: error_string }
-      render action: "new"
+      render :new, status: :unprocessable_entity
     end
   end
 
   def update
     if @application.update(application_params)
-
-      flash.now[:notice] = { message: "Successfully updated the application details" }
-
-      render action: "show"
+      redirect_to @application, notice: "Successfully updated the application details"
     else
-      errors = @application.errors.full_messages
-
-      error_string = errors.join(", ")
-
-      flash.now[:error] = { message: "There was a problem updating the application details", description: error_string }
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -1,4 +1,10 @@
 class DeploymentsController < ApplicationController
+  class ApplicationConflictError < RuntimeError; end
+
+  rescue_from ApplicationConflictError do
+    head :conflict
+  end
+
   def index
     @application = Application.friendly.find(params[:application_id])
     @deployments = @application.deployments.newest_first.limit(100)
@@ -68,11 +74,7 @@ private
     when 1
       existing_apps[0]
     else
-      flash[:alert] = {
-        message: sprintf("Found multiple applications using repo: %<repo_path>s while using application_by_repo", repo_path: repo_path),
-      }
-      render :new
-      nil
+      raise ApplicationConflictError
     end
   end
 

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -54,12 +54,11 @@ class DeploymentsController < ApplicationController
         application.archived = false
         application.save!
 
-        flash.now[:notice] = { message: "Deployment created for #{application.name}" }
+        redirect_to application_path(application), notice: "Deployment created for #{application.name}"
       else
-        flash[:alert] = { message: "Failed to create deployment" }
+        render :new, status: :unprocessable_entity
       end
 
-      render :new
     end
   end
 

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,10 +3,10 @@ class SitesController < ApplicationController
 
   def update
     if site_settings.update(site_params)
-      flash.now[:notice] = { message: "Site settings updated" }
+      redirect_to root_path, notice: "Site settings updated"
+    else
+      render :show, status: :unprocessable_entity
     end
-
-    render :show
   end
 
 private

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -8,7 +8,7 @@ class Application < ApplicationRecord
 
   validates :name, :repo, :status_notes, :shortname, length: { maximum: 255 }
 
-  validates :repo, format: { with: /\A[^\s\/]+\/[^\s\/]+\Z/i }
+  validates :repo, format: { with: /\A[^\s\/]+\/[^\s\/]+\Z/i }, allow_blank: true
 
   validates :name, uniqueness: { case_sensitive: true }
 

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -4,7 +4,8 @@
       text: "Application name"
     },
     name: "application[name]",
-    value: @application.name
+    value: @application.name,
+    error_message: @application.errors[:name].first,
   } %>
 
   <%= render "govuk_publishing_components/components/input", {
@@ -13,13 +14,15 @@
     },
     name: "application[repo]",
     hint: "Example: alphagov/publisher",
-    value: @application.repo
+    value: @application.repo,
+    error_message: @application.errors[:repo].first,
   } %>
 
   <%= render "govuk_publishing_components/components/select", {
     id: "default_branch",
     label: "GitHub repository default branch",
     name: "application[default_branch]",
+    error_message: @application.errors[:default_branch].first,
     options: Application.default_branches.map do |(id, label)|
       {
         text: label,
@@ -35,7 +38,8 @@
     },
     name: "application[shortname]",
     hint: "For use in graphite metrics. Example: whitehall",
-    value: @application.shortname
+    value: @application.shortname,
+    error_message: @application.errors[:shortname].first,
   } %>
 
   <%= render "govuk_publishing_components/components/textarea", {
@@ -44,7 +48,8 @@
     },
     hint: "Use for deploy instructions and deploy freezes",
     name: "application[status_notes]",
-    value: @application.status_notes
+    value: @application.status_notes,
+    error_message: @application.errors[:status_notes].first,
   } %>
 
   <input type="hidden" name="application[archived]" value="0" />
@@ -85,8 +90,6 @@
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Update application",
-    name: "application[commit]",
-    value: "Update application"
+    text: @application.new_record? ? "Create Application" : "Update application",
   } %>
 <% end %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -2,4 +2,6 @@
 
 <%= render partial: "shared/application_header", locals: { application: @application, tab: "edit" } %>
 
+<%= render "shared/form_errors", resource: @application %>
+
 <%= render partial: "form", locals: { application: @application } %>

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -9,6 +9,8 @@
   ]
 } %>
 
+<%= render "shared/form_errors", resource: @application %>
+
 <%= render "govuk_publishing_components/components/title", {
   title: "Create new application"
 } %>

--- a/app/views/deployments/new.html.erb
+++ b/app/views/deployments/new.html.erb
@@ -8,6 +8,8 @@
   ]
 } %>
 
+<%= render "shared/form_errors", resource: @deployment %>
+
 <%= render "govuk_publishing_components/components/title", {
   title: "Manually record a deployment"
 } %>
@@ -21,7 +23,7 @@
     {
       text: application.name,
       value: application.id,
-      selected: (true if application.shortname.present? && request.path.include?(application.shortname))
+      selected: application.id == @deployment.application_id,
     }
   end
 %>
@@ -31,51 +33,62 @@
     id: "deployment_application_id",
     label: "Application",
     name: "deployment[application_id]",
-    options: applications
+    options: applications,
+    error_message: @deployment.errors[:application].first,
   } %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "Environment"
     },
-    name: "deployment[environment]"
+    name: "deployment[environment]",
+    value: @deployment.environment,
+    error_message: @deployment.errors[:environment].first,
   } %>
 
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "Version"
     },
-    name: "deployment[version]"
+    name: "deployment[version]",
+    value: @deployment.version,
+    error_message: @deployment.errors[:version].first,
   } %>
 
   <%= render "govuk_publishing_components/components/date_input", {
     legend_text: "When was this deployment made?",
     hint: "Please enter in format: DD MM YYYY HH MM. For example: 25 8 2019 09 00",
+    error_message: @deployment.errors[:created_at].first,
     items: [
       {
         label: "Day",
         name: "deployment[created_at(3i)]",
-        width: 2
+        width: 2,
+        value: @deployment.created_at&.day,
       },
       {
         label: "Month",
         name: "deployment[created_at(2i)]",
-        width: 2
+        width: 2,
+        value: @deployment.created_at&.month,
       },
       {
         label: "Year",
         name: "deployment[created_at(1i)]",
-        width: 4
+        width: 4,
+        value: @deployment.created_at&.year,
       },
       {
         label: "Hour",
         name: "deployment[created_at(4i)]",
-        width: 2
+        width: 2,
+        value: @deployment.created_at&.hour,
       },
       {
         label: "Minutes",
         name: "deployment[created_at(5i)]",
-        width: 2
+        width: 2,
+        value: @deployment.created_at&.min,
       }
     ]
   } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,12 +20,8 @@
     <div class="release__non-production-banner">THIS IS NOT THE CANONICAL RELEASE APP. GO TO <a class="govuk-link" href="https://release.publishing.service.gov.uk">PRODUCTION</a> TO SEE CURRENT RELEASES IN ALL ENVIRONMENTS.</div>
   <% end %>
   <main class="govuk-main-wrapper govuk-!-padding-top-2" id="main-content" role="main">
-    <% [:notice, :alert, :error].select { |k| flash[k].present? }.each do |k| %>
-        <% if k.eql?(:notice) %>
-          <%= render "govuk_publishing_components/components/success_alert", flash[k] %>
-        <% else%>
-          <%= render "govuk_publishing_components/components/error_alert", flash[k] %>
-        <% end %>
+    <% if flash[:notice] %>
+      <%= render "govuk_publishing_components/components/success_alert", message: flash[:notice] %>
     <% end %>
 
     <%= yield %>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,0 +1,6 @@
+<% if resource.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: resource.errors.full_messages.map { |message| { text: message } }
+  } %>
+<% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -8,6 +8,8 @@
   ]
 } %>
 
+<%= render "shared/form_errors", resource: site_settings %>
+
 <%= render "govuk_publishing_components/components/title", {
   title: "Site settings"
 } %>
@@ -20,6 +22,7 @@
       },
       name: "site[status_notes]",
       value: site_settings.status_notes,
+      error_message: site_settings.errors[:status_notes].first,
     },
     maxlength: 255
   } %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -42,8 +42,20 @@ class ApplicationsControllerTest < ActionController::TestCase
   end
 
   context "POST create" do
-    should "create an application" do
-      assert_difference "Application.count", 1 do
+    context "valid request" do
+      should "create an application" do
+        assert_difference "Application.count", 1 do
+          post :create,
+               params: {
+                 application: {
+                   name: "My First App",
+                   repo: "org/my_first_app",
+                 },
+               }
+        end
+      end
+
+      should "redirect to the application" do
         post :create,
              params: {
                application: {
@@ -51,21 +63,20 @@ class ApplicationsControllerTest < ActionController::TestCase
                  repo: "org/my_first_app",
                },
              }
+        assert_redirected_to application_path(Application.last)
       end
     end
 
     context "invalid request" do
       should "render an error message" do
         post :create, params: { application: { name: "", repo: "org/my_first_app" } }
-        assert_select ".gem-c-error-alert"
-        assert_select ".gem-c-error-summary__title", text: "There was a problem creating the new application"
-        assert_select ".gem-c-error-summary__body", text: "Name is required"
+        assert_select ".gem-c-error-summary__list-item", text: "Name is required"
       end
 
-      should "rerender the form" do
+      should "rerender the form and respond with an unprocessable entity status" do
         post :create, params: { application: { name: "", repo: "org/my_first_app" } }
-        assert_select "form#new_application input[name='application[name]']"
-        assert_select "form#new_application input[name='application[repo]'][value='org/my_first_app']"
+        assert_template :new
+        assert_response :unprocessable_entity
       end
     end
   end
@@ -228,27 +239,31 @@ class ApplicationsControllerTest < ActionController::TestCase
       @app = FactoryBot.create(:application)
     end
 
-    should "update the application" do
-      put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true, deploy_freeze: true } }
-      @app.reload
-      assert_equal "new name", @app.name
-      assert_equal true, @app.on_aws?
-      assert_equal true, @app.deploy_freeze?
+    context "valid request" do
+      should "update the application" do
+        put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true, deploy_freeze: true } }
+        @app.reload
+        assert_equal "new name", @app.name
+        assert_equal true, @app.on_aws?
+        assert_equal true, @app.deploy_freeze?
+      end
+
+      should "redirect to the application" do
+        put :update, params: { id: @app.id, application: { name: "new name", repo: "new/repo", on_aws: true, deploy_freeze: true } }
+        assert_redirected_to application_path(@app)
+      end
     end
 
     context "invalid request" do
       should "render an error message" do
         put :update, params: { id: @app.id, application: { name: "", repo: "new/repo" } }
-        assert_select ".gem-c-error-alert"
-        assert_select ".gem-c-error-summary__title", text: "There was a problem updating the application details"
-        assert_select ".gem-c-error-summary__body", text: "Name is required"
+        assert_select ".gem-c-error-summary__list-item", text: "Name is required"
       end
 
-      should "rerender the form" do
+      should "rerender the form and respond with an unprocessable entity status" do
         put :update, params: { id: @app.id, application: { name: "", repo: "new/repo" } }
-        @app.reload
-        assert_select "form.edit_application input[name='application[name]'][value='']"
-        assert_select "form.edit_application input[name='application[repo]'][value='new/repo']"
+        assert_template :edit
+        assert_response :unprocessable_entity
       end
     end
   end

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -148,6 +148,15 @@ class DeploymentsControllerTest < ActionController::TestCase
           assert_equal "New App", app.name
         end
       end
+
+      context "handling multiple applications with the same repo" do
+        should "return a conflict response" do
+          FactoryBot.create(:application, name: "app 1", repo: "org/app")
+          FactoryBot.create(:application, name: "app 2", repo: "org/app")
+          post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging" } }
+          assert_response :conflict
+        end
+      end
     end
   end
 end

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -52,10 +52,18 @@ class DeploymentsControllerTest < ActionController::TestCase
         assert_equal "2013-01-18 11:57:00 +0000", deployment.created_at.to_s
       end
 
-      should "redisplay the form on error" do
+      should "redirect to the application on a successful create" do
+        app = FactoryBot.create(:application, repo: "org/app")
+        post :create, params: { deployment: { application_id: app.id, version: "release_123", environment: "staging", created_at: "18/01/2013 11:57" } }
+
+        assert_redirected_to application_path(app)
+      end
+
+      should "redisplay the form and respond with a 422 when there is an error" do
         app = FactoryBot.create(:application, repo: "org/app")
         post :create, params: { deployment: { application_id: app.id, version: "", environment: "staging", created_at: "18/01/2013 11:57" } }
         assert_template :new
+        assert_response :unprocessable_entity
       end
 
       should "unarchive an archived application" do

--- a/test/functional/sites_controller_test.rb
+++ b/test/functional/sites_controller_test.rb
@@ -41,5 +41,17 @@ class SitesControllerTest < ActionController::TestCase
 
       assert_equal "Deploy freeze in place.", site_settings.reload.status_notes
     end
+
+    should "redirect to the root on a successful update" do
+      patch :update, params: { site: { status_notes: "Deploy freeze in place." } }
+
+      assert_redirected_to root_path
+    end
+
+    should "respond with an unprocessable entity for invalid input" do
+      patch :update, params: { site: { status_notes: SecureRandom.alphanumeric(1000) } }
+
+      assert_response :unprocessable_entity
+    end
   end
 end

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -21,7 +21,7 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
     fill_in "Notes", with: "Christmas deploy freeze in place. Emergency deploys only until 2nd Jan"
     click_on "Save status notes"
     assert page.has_selector?(".gem-c-success-alert", text: "Site settings updated")
-    assert_equal "/site", current_path
+    assert_equal "/applications", current_path
 
     visit "/"
     click_on @app1.name
@@ -40,7 +40,7 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
     fill_in "Notes", with: ""
     click_on "Save status notes"
     assert page.has_selector?(".gem-c-success-alert", text: "Site settings updated")
-    assert_equal "/site", current_path
+    assert_equal "/applications", current_path
 
     visit "/"
     click_on @app1.name


### PR DESCRIPTION
Trello: https://trello.com/c/JPM4Qqro/208-update-release-app-to-support-apps-without-a-master-branch (tangentially)

In https://github.com/alphagov/release/pull/771 I discovered there were a variety of issues related to form and flash message handling in this app. It looks like all forms had been set to no longer redirect on save, which produced some odd issues and there was a lack of information available when forms had errors. I've gone through and fixed these while also improving the HTTP semantics and adding tests. Further details are in the commits.

Here are some screenshots to illustrate before and after.

## Successful submission of an application update

Before:
![Screenshot 2021-02-25 at 10 20 30](https://user-images.githubusercontent.com/282717/109141057-33357900-7755-11eb-9e52-42733480397a.png)

After:
![Screenshot 2021-02-25 at 10 28 10](https://user-images.githubusercontent.com/282717/109141088-3cbee100-7755-11eb-9bbc-f31251d5b27c.png)

## Validation errors when updating an application

Before:
![Screenshot 2021-02-25 at 10 21 39](https://user-images.githubusercontent.com/282717/109141160-53fdce80-7755-11eb-99ca-b0f825ebe1a6.png)

After:
![Screenshot 2021-02-25 at 10 28 38](https://user-images.githubusercontent.com/282717/109141184-5b24dc80-7755-11eb-949e-803e57987ceb.png)

## Validation errors when adding a manual deployment

Before:
![Screenshot 2021-02-25 at 10 22 15](https://user-images.githubusercontent.com/282717/109141255-72fc6080-7755-11eb-9436-03c385a83a1b.png)

After:
![Screenshot 2021-02-25 at 10 29 20](https://user-images.githubusercontent.com/282717/109141240-6d9f1600-7755-11eb-8fb7-895a5a5bbdc1.png)

## Validation error when updating site settings

Before:
![Screenshot 2021-02-25 at 10 20 44](https://user-images.githubusercontent.com/282717/109140781-e0f45800-7754-11eb-949c-ebd8e66b1dcd.png)

After:
![Screenshot 2021-02-25 at 10 27 30](https://user-images.githubusercontent.com/282717/109140799-e5207580-7754-11eb-99bb-41d503d21ebf.png)
