### PR TITLE
Improve deployment monitoring on Integration and Production

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -77,8 +77,8 @@
     } %>
     <p class="govuk-body">
       <%= octicon "graph", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-      <a target="_blank" href="<%= dashboard_url(@application, "staging") %>" class="govuk-link">Staging dashboard</a>:
-      Monitor your deployment to check that it doesn't cause any problems.
+      <a target="_blank" href="<%= dashboard_url(@application, "integration") %>" class="govuk-link">Integration dashboard</a>:
+      Monitor your deployment to check that it hasn't caused any problems.
     </p>
     <p class="govuk-body">
       <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
@@ -99,7 +99,7 @@
     } %>
     <p class="govuk-body">
       <%= octicon "graph", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-      <a target="_blank" href="<%= dashboard_url(@application, "production") %>" class="govuk-link">Production dashboard</a>:
+      <a target="_blank" href="<%= dashboard_url(@application, "staging") %>" class="govuk-link">Staging dashboard</a>:
       Monitor your deployment to check that it doesn't cause any problems.
     </p>
     <p class="govuk-body">
@@ -114,5 +114,21 @@
       destructive: true,
       margin_bottom: true
     } %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Monitor Production",
+      margin_bottom: 4,
+      heading_level: 3
+    } %>
+    <p class="govuk-body">
+      <%= octicon "graph", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
+      <a target="_blank" href="<%= dashboard_url(@application, "production") %>" class="govuk-link">Production dashboard</a>:
+      Monitor your deployment to check that it doesn't cause any problems.
+    </p>
+    <p class="govuk-body">
+      <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
+      <a target="_blank" href="<%= smokey_url(@application, "production") %>" class="govuk-link">Production smokey</a>:
+      Check Smokey has run in Production and your deploy didn't cause any problems.
+    </p>
   </div>
 </div>


### PR DESCRIPTION
The previous Deployment screen was missing a link to the Integration
dashboard, and to the Production dashboard. This discouraged devs
from visiting these dashboards.
In the case of the former, this means developers may not see issues
with their deploy until they release to Staging and check Grafana.
In the case of the latter, this means developers may not spot any
issues that only affect Production.

Before:

![before](https://user-images.githubusercontent.com/5111927/109946419-1f978e80-7cd0-11eb-8c65-f7604eabfe6e.png)

After:

![after](https://user-images.githubusercontent.com/5111927/109946442-26260600-7cd0-11eb-885e-eb3df9fdd937.png)