### PR TITLE
Add count of unmerged dependency PRs to the application page

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,6 +23,8 @@ class ApplicationsController < ApplicationController
     respond_to do |format|
       format.json { render json: @application }
       format.html do
+        @outstanding_dependency_pull_requests = Services.github.search_issues("repo:#{@application.repo} is:pr state:open label:dependencies")[:total_count]
+
         @tags_by_commit = Services.github.tags(@application.repo).each_with_object({}) do |tag, hash|
           sha = tag[:commit][:sha]
           hash[sha] ||= []

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -9,6 +9,10 @@ module UrlHelper
     "https://deploy.#{suffix}/job/Smokey"
   end
 
+  def github_dependency_link_to(app, text)
+    link_to(text, "#{app.repo_url}/pulls?q=is%3Apr+state%3Aopen+label%3Adependencies", target: "_blank", rel: "noopener", class: "govuk-link")
+  end
+
   def github_tag_link_to(app, git_ref)
     link_to(git_ref.truncate(15), "#{app.repo_url}/tree/#{git_ref}", target: "_blank", rel: "noopener", class: "govuk-link")
   end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -88,6 +88,24 @@
   <% end %>
 <% end %>
 
+<% if @github_available %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Outstanding dependencies",
+    heading_level: 3,
+    margin_bottom: 4,
+  } %>
+
+  <div>
+    <% if @outstanding_dependency_pull_requests.zero? %>
+      <p class="govuk-body">There are <%= github_dependency_link_to(@application, "no outstanding dependency pull requests") %>.</p>
+    <% elsif @outstanding_dependency_pull_requests == 1 %>
+      <p class="govuk-body">There is <%= github_dependency_link_to(@application, "one outstanding dependency pull request") %>.</p>
+    <% else %>
+      <p class="govuk-body">There are <%= github_dependency_link_to(@application, "#{@outstanding_dependency_pull_requests} outstanding dependency pull requests") %>.</p>
+    <% end %>
+  </div>
+<% end %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: "What's where?",
   heading_level: 2,

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -89,5 +89,11 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
         },
       ])
     stub_request(:get, "https://grafana.dev.gov.uk:80/api/dashboards/file/#{application.shortname}.json").to_return(status: 200, body: "")
+
+    Octokit::Client.any_instance.stubs(:search_issues)
+        .with("repo:#{application.repo} is:pr state:open label:dependencies")
+        .returns({
+          "total_count": 5,
+        })
   end
 end


### PR DESCRIPTION
This will allow developers to see if there are outstanding dependency pull requests before they deploy an application, which should hopefully help us to reduce the number of unmerged dependabot PRs.

## Examples

### No outstanding PRs

![Screenshot 2021-03-10 at 13 37 02](https://user-images.githubusercontent.com/6329861/110651520-6c3d0700-81b3-11eb-9146-5504618c9cfe.png)

### One outstanding PR

![Screenshot 2021-03-10 at 13 37 24](https://user-images.githubusercontent.com/6329861/110651526-6d6e3400-81b3-11eb-8383-150b79bebe6d.png)

## More than one outstanding PR

![Screenshot 2021-03-10 at 13 37 46](https://user-images.githubusercontent.com/6329861/110651531-6e06ca80-81b3-11eb-8b0b-0a2f5336b159.png)
