### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,16 @@
 
 An application to make managing releases to specific environments easier.
 
-## Getting started
+## Technical documentation
 
-1. Create app-specific mysql user (check [config/database.yml](config/database.yml) for user details):
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-    ```
-    mysql.server start
-    mysql -u root
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-    # Create release user
-    CREATE USER 'release'@'localhost' IDENTIFIED BY 'release';
-    GRANT ALL PRIVILEGES
-    ON `release_%`.*
-    TO 'release'@'localhost'
-    WITH GRANT OPTION;
-    FLUSH PRIVILEGES;
-    exit
-    ```
+**Use GOV.UK Docker to run any commands that follow.**
 
-2. Install dependencies, create databases and run initial migrations, test:
-    ```
-    bundle install
-    bundle exec rake db:create:all db:migrate
-    bundle exec rake
-    ```
-3. Create applications in [db/seeds.rb](db/seeds.rb):
+### To the run the tests
 
-    ```
-    bundle exec rake db:seed
-    ```
+```
+bundle exec rake
+```

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails server -p 3036


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This follows the pattern established in [1]. Note that all of the
setup instructions are covered by the build in GOV.UK Docker, and
moreover can be achieved with more conventional Rails commands. I
also double-checked this repo builds and starts as expected.

[1]: https://github.com/alphagov/content-publisher/pull/2257