### PR TITLE
Change application default branch to main

### DIFF
--- a/db/migrate/20210319081818_change_applications_default_branch.rb
+++ b/db/migrate/20210319081818_change_applications_default_branch.rb
@@ -1,0 +1,5 @@
+class ChangeApplicationsDefaultBranch < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :applications, :default_branch, from: "master", to: "main"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_004602) do
+ActiveRecord::Schema.define(version: 2021_03_19_081818) do
 
   create_table "applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_004602) do
     t.boolean "archived", default: false, null: false
     t.boolean "on_aws", default: false, null: false
     t.boolean "deploy_freeze", default: false, null: false
-    t.string "default_branch", default: "master", null: false
+    t.string "default_branch", default: "main", null: false
     t.index ["name"], name: "index_applications_on_name", unique: true
     t.index ["repo"], name: "index_applications_on_repo"
     t.index ["shortname"], name: "index_applications_on_shortname"


### PR DESCRIPTION
Any new repos created in GitHub will have a `main` branch now rather than a `master` one, so it seems reasonable to change the default over to `main` now, even if the vast majority of our existing applications still use a `master` branch.