### PR TITLE
Deploy lag report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "uglifier"
 group :test, :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "byebug"
   gem "capybara"
   gem "database_cleaner"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -339,6 +340,7 @@ DEPENDENCIES
   active_model_serializers
   better_errors
   binding_of_caller
+  byebug
   capybara
   chartkick
   database_cleaner

--- a/lib/report/deploy_lag_report.rb
+++ b/lib/report/deploy_lag_report.rb
@@ -1,13 +1,13 @@
 class Report
   class DeployLagReport
-    def call
-      Application.all.flat_map { |app| deploy_sequences_for(app) }.compact
+    def call(start_date, end_date)
+      Application.all.flat_map { |app| deploy_sequences_for(app, start_date, end_date) }.compact
     end
 
   private
 
-    def deploy_sequences_for(app)
-      deploys = Deployment.where("created_at > ?", 1.year.ago).where(application: app)
+    def deploy_sequences_for(app, start_date, end_date)
+      deploys = Deployment.where("created_at BETWEEN ? AND ?", start_date, end_date).where(application: app)
 
       integration_deploys = deploys
         .where("environment LIKE 'integration%'")

--- a/lib/report/deploy_lag_report.rb
+++ b/lib/report/deploy_lag_report.rb
@@ -1,0 +1,51 @@
+class Report
+  class DeployLagReport
+    def call
+      Application.all.flat_map { |app| deploy_sequences_for(app) }.compact
+    end
+
+  private
+
+    def deploy_sequences_for(app)
+      deploys = Deployment.where("created_at > ?", 1.year.ago).where(application: app)
+
+      integration_deploys = deploys
+        .where("environment LIKE 'integration%'")
+        .select { |dep| dep.version =~ /release_/ }
+
+      production_deploys = deploys
+        .where("environment LIKE 'production%'")
+        .select { |dep| dep.version =~ /release_/ }
+
+      production_by_version = production_deploys.group_by { |dep| release_number_for(dep) }
+
+      integration_deploys.map do |dep|
+        prod_deploy = production_deploy_for(dep, production_by_version)
+        next unless prod_deploy
+
+        { app: app, deploy: dep, prod_deploy: prod_deploy }
+      end
+    end
+
+    def production_deploy_for(deploy, by_version)
+      version_no = release_number_for(deploy)
+      prod_deploy = nil
+
+      while prod_deploy.nil?
+        return nil if version_no > (by_version.keys.max || 0)
+
+        prod_deploys = by_version[version_no]
+        version_no += 1
+        next if prod_deploys.nil?
+
+        prod_deploy = prod_deploys.first
+      end
+
+      prod_deploy
+    end
+
+    def release_number_for(deploy)
+      deploy.version.split("_")[1].to_i
+    end
+  end
+end

--- a/lib/tasks/deploy_lag.rake
+++ b/lib/tasks/deploy_lag.rake
@@ -1,12 +1,12 @@
 require "csv"
 require "report/deploy_lag_report"
 
-desc "Output a CSV report of deploy lags by app and month"
-task deploy_lag: :environment do
+desc "Output a CSV report of deploy lags by app and month between two dates 'YYYY-MM-DD'"
+task :deploy_lag, %w[start_date end_date] => :environment do |_, args|
   puts(CSV.generate do |csv|
     csv << %w[short_name timestamp version prod_deploy_timestamp prod_deploy_version]
 
-    Report::DeployLagReport.new.call.each do |sequence|
+    Report::DeployLagReport.new.call(args[:start_date], args[:end_date]).each do |sequence|
       csv << [
         sequence[:app].shortname,
         sequence[:deploy].created_at,

--- a/lib/tasks/deploy_lag.rake
+++ b/lib/tasks/deploy_lag.rake
@@ -1,0 +1,19 @@
+require "csv"
+require "report/deploy_lag_report"
+
+desc "Output a CSV report of deploy lags by app and month"
+task deploy_lag: :environment do
+  puts(CSV.generate do |csv|
+    csv << %w[short_name timestamp version prod_deploy_timestamp prod_deploy_version]
+
+    Report::DeployLagReport.new.call.each do |sequence|
+      csv << [
+        sequence[:app].shortname,
+        sequence[:deploy].created_at,
+        sequence[:deploy].version,
+        sequence[:prod_deploy].created_at,
+        sequence[:prod_deploy].version,
+      ]
+    end
+  end)
+end

--- a/test/unit/report/deploy_lag_report_test.rb
+++ b/test/unit/report/deploy_lag_report_test.rb
@@ -4,13 +4,14 @@ require "report/deploy_lag_report"
 class Report::DeployLagReportTest < ActiveSupport::TestCase
   setup do
     @app = FactoryBot.create(:application)
+    @start_date = 1.year.ago.strftime("%Y-%m-%d")
+    @end_date = (Time.zone.today + 1).to_s
   end
 
   test "pair up the Integration <-> Production deployments" do
     deploy = FactoryBot.create(:deployment, environment: "integration", version: "release_123", application: @app)
     prod_deploy = FactoryBot.create(:deployment, environment: "production", version: "release_124", application: @app)
-
-    sequences = Report::DeployLagReport.new.call
+    sequences = Report::DeployLagReport.new.call(@start_date, @end_date)
     assert_equal(deploy, sequences.first[:deploy])
     assert_equal(prod_deploy, sequences.first[:prod_deploy])
     assert_equal(@app, sequences.first[:app])
@@ -19,7 +20,7 @@ class Report::DeployLagReportTest < ActiveSupport::TestCase
 
   test "ignore deploys without a production deployment" do
     FactoryBot.create(:deployment, environment: "integration", version: "release_123", application: @app)
-    sequences = Report::DeployLagReport.new.call
+    sequences = Report::DeployLagReport.new.call(@start_date, @end_date)
     assert_equal([], sequences)
   end
 
@@ -27,7 +28,7 @@ class Report::DeployLagReportTest < ActiveSupport::TestCase
     FactoryBot.create(:deployment, environment: "integration", version: "foo-bar", application: @app)
     FactoryBot.create(:deployment, environment: "production", version: "release_124", application: @app)
 
-    sequences = Report::DeployLagReport.new.call
+    sequences = Report::DeployLagReport.new.call(@start_date, @end_date)
     assert_equal([], sequences)
   end
 
@@ -35,8 +36,17 @@ class Report::DeployLagReportTest < ActiveSupport::TestCase
     deploy = FactoryBot.create(:deployment, environment: "integration", version: "release_123", application: @app)
     prod_deploy = FactoryBot.create(:deployment, environment: "production", version: "release_124", application: @app)
 
-    sequences = Report::DeployLagReport.new.call
+    sequences = Report::DeployLagReport.new.call(@start_date, @end_date)
     assert_equal(deploy, sequences.first[:deploy])
     assert_equal(prod_deploy, sequences.first[:prod_deploy])
+  end
+
+  test "ignores deploys that are outside of the selected time range" do
+    FactoryBot.create(:deployment, created_at: 2.years.ago, environment: "integration", version: "release_123", application: @app)
+    FactoryBot.create(:deployment, created_at: 2.years.ago, environment: "production", version: "release_123", application: @app)
+
+    sequences = Report::DeployLagReport.new.call(@start_date, @end_date)
+
+    assert_equal([], sequences)
   end
 end

--- a/test/unit/report/deploy_lag_report_test.rb
+++ b/test/unit/report/deploy_lag_report_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "report/deploy_lag_report"
+
+class Report::DeployLagReportTest < ActiveSupport::TestCase
+  setup do
+    @app = FactoryBot.create(:application)
+  end
+
+  test "pair up the Integration <-> Production deployments" do
+    deploy = FactoryBot.create(:deployment, environment: "integration", version: "release_123", application: @app)
+    prod_deploy = FactoryBot.create(:deployment, environment: "production", version: "release_124", application: @app)
+
+    sequences = Report::DeployLagReport.new.call
+    assert_equal(deploy, sequences.first[:deploy])
+    assert_equal(prod_deploy, sequences.first[:prod_deploy])
+    assert_equal(@app, sequences.first[:app])
+    assert_equal(1, sequences.length)
+  end
+
+  test "ignore deploys without a production deployment" do
+    FactoryBot.create(:deployment, environment: "integration", version: "release_123", application: @app)
+    sequences = Report::DeployLagReport.new.call
+    assert_equal([], sequences)
+  end
+
+  test "ignore deploys that are not a release (e.g. branches)" do
+    FactoryBot.create(:deployment, environment: "integration", version: "foo-bar", application: @app)
+    FactoryBot.create(:deployment, environment: "production", version: "release_124", application: @app)
+
+    sequences = Report::DeployLagReport.new.call
+    assert_equal([], sequences)
+  end
+
+  test "ignore the hosting provider (AWS vs. Carrenza)" do
+    deploy = FactoryBot.create(:deployment, environment: "integration", version: "release_123", application: @app)
+    prod_deploy = FactoryBot.create(:deployment, environment: "production", version: "release_124", application: @app)
+
+    sequences = Report::DeployLagReport.new.call
+    assert_equal(deploy, sequences.first[:deploy])
+    assert_equal(prod_deploy, sequences.first[:prod_deploy])
+  end
+end


### PR DESCRIPTION
This adds a new rake task to report, for each Integration deploy, the corresponding Production deploy.

The task will take two date arguments in the format `YYYY-MM-DD` to set the date range to report on.

`'rake deploy_lag[2020-01-01,2021-12-31]'`

[Trello](https://trello.com/c/i8OUTThq/2475-2-re-run-metrics-for-delayed-deploys-for-aug-2020-mar-2021)