### PR TITLE
Remove context link to app repo

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -15,7 +15,6 @@
     title: "Deploy #{@application.name}",
     context: {
       text: @application.shortname,
-      href: @application.repo_url
     },
     margin_bottom: 2
   } %>


### PR DESCRIPTION
The contextual link has been removed from the component, see:
https://github.com/alphagov/govuk_publishing_components/pull/2192
