### PR TITLE
Un-nest `context.text` in deployments page

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -13,9 +13,7 @@
 
   <%= render "govuk_publishing_components/components/title", {
     title: "Deploy #{@application.name}",
-    context: {
-      text: @application.shortname,
-    },
+    context: @application.shortname,
     margin_bottom: 2
   } %>
   <%= render partial: "shared/badges", locals: { application: @application } %>


### PR DESCRIPTION
This should have been done in #860 

Currently, it looks like this, with an extra `text`:

<img width="476" alt="Screenshot 2021-08-24 at 09 33 42" src="https://user-images.githubusercontent.com/75235/130584656-9920d3ee-2989-42d0-8018-7d4d88197e64.png">
