### PR TITLE
Add some apps that were overlooked/misnamed

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -7,6 +7,7 @@
 - content-data-admin
 - content-data-api
 - content-publisher
+- email-alert-frontend
 - email-alert-service
 - finder-frontend
 - frontend
@@ -25,7 +26,8 @@
 - service-manual-frontend
 - service-manual-publisher
 - short-url-manager
-- smart-answers
+- sidekiq-monitoring
+- smartanswers
 - support
 - travel-advice-publisher
 - whitehall


### PR DESCRIPTION
- Smart Answers was named differently between the two apps
- sidekiq-monitoring didn't have an app page in the dev docs
- email alert frontend didn't seem to be listed as CD in the dev docs, but [puppet says it is](https://github.com/alphagov/govuk-puppet/pull/10877) which is what counts.

https://trello.com/c/k1jNBLTh/2565-improve-how-apps-are-marked-as-being-continuously-deployed-in-the-release-app-3