### PR TITLE
Add 'continuously_deployed' status to JSON representation of apps

### DIFF
--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -4,4 +4,5 @@ class ApplicationSerializer < ActiveModel::Serializer
   attribute :repo_url, key: :repository_url
   attribute :default_branch, key: :repository_default_branch
   attribute :on_aws, key: :hosted_on_aws
+  attribute :cd_enabled?, key: :continuously_deployed
 end

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -195,6 +195,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         assert_equal false, body["archived"]
         assert_equal false, body["deploy_freeze"]
         assert_equal false, body["hosted_on_aws"]
+        assert_equal false, body["continuously_deployed"]
         assert_equal "https://github.com/alphagov/application-1", body["repository_url"]
       end
     end


### PR DESCRIPTION
The Release app provides a way of viewing the data about each app
in JSON form, e.g.
https://release.publishing.service.gov.uk/applications/account-api.json

In #880, we added a new field associated with each app, to denote
whether or not the app is 'continuously deployed'. We should
expose this in the JSON too.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
