### PR TITLE
Fix previous deploy info

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -131,7 +131,7 @@
         <%= t.header environment.humanize %>
         <%= t.cell "#{github_tag_link_to(@application, deployment.version)} at #{human_datetime(deployment.created_at)}".html_safe() %>
         <% previous_version = deployment.previous_deployment ? "#{github_tag_link_to(@application, deployment.previous_deployment.version)} at #{human_datetime(deployment.previous_deployment.created_at)}".html_safe() : "N/A" %>
-        <%= t.cell "#{github_tag_link_to(@application, deployment.version)} at #{human_datetime(deployment.created_at)}".html_safe() %>
+        <%= t.cell previous_version %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Previous deploy info currently just always shows the current deploy,
looks like the info was correctly retrieved but not plumbed in.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
