### PR TITLE
Revert "Rotate SHA1 encrypted cookies to SHA256"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,22 +37,5 @@ module ReleaseApp
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
-
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.secrets.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
   end
 end


### PR DESCRIPTION
This reverts commit 84ca7873273f6c739537d266380be22f6ee7610b, now that Rails has been upgraded.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
