### PR TITLE
Clarify Smokey needs to be run manually now

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -80,7 +80,7 @@
     <p class="govuk-body">
       <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
       <a target="_blank" href="<%= smokey_url(@application, "integration") %>" class="govuk-link">Integration smokey</a>:
-      Check Smokey has run in Integration and your deploy didn't cause any problems.
+      Run Smokey in Integration and check your deploy didn't cause any problems.
     </p>
     <%= render "govuk_publishing_components/components/button", {
       text: "Deploy to Staging",
@@ -102,7 +102,7 @@
     <p class="govuk-body">
       <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
       <a target="_blank" href="<%= smokey_url(@application, "staging") %>" class="govuk-link">Staging smokey</a>:
-      Check Smokey has run in Staging and your deploy didn't cause any problems.
+      Run Smokey in Staging and check your deploy didn't cause any problems.
     </p>
     <%= render "govuk_publishing_components/components/button", {
       text: "Deploy to Production",
@@ -125,7 +125,7 @@
     <p class="govuk-body">
       <%= octicon "circuit-board", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
       <a target="_blank" href="<%= smokey_url(@application, "production") %>" class="govuk-link">Production smokey</a>:
-      Check Smokey has run in Production and your deploy didn't cause any problems.
+      Run Smokey in Production and check your deploy didn't cause any problems.
     </p>
   </div>
 </div>


### PR DESCRIPTION
In response to: [^1][^2].

This is slightly misleading as Puppet deploys do still run Smokey
automatically, but the deployer should still make the effort to
check this so the language is still appropriate.

The Production checks are arguably unnecessary for apps given the
checks done in previous environments. However, we may as well keep
recommending them for manually deployed apps, which aren't tested
as thoroughly (yet) - and definitely for Puppet.

[^1]: https://github.com/alphagov/govuk-puppet/pull/11611#pullrequestreview-937766486
[^2]: https://github.com/alphagov/govuk-puppet/pull/11611#pullrequestreview-931760518


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️