### PR TITLE
Add specialist publisher to continuously deployed apps yaml

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -31,6 +31,7 @@
 - short-url-manager
 - sidekiq-monitoring
 - smartanswers
+- specialist-publisher
 - support
 - travel-advice-publisher
 - whitehall


### PR DESCRIPTION
For the ticket on [enabling CD for specialist publisher](https://trello.com/c/NfdjEbQi/261-enable-continuous-deployment-for-specialist-publisher).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
