### PR TITLE
Mark publishing-api as continuously deployed

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -25,6 +25,7 @@
 - manuals-publisher
 - maslow
 - publisher
+- publishing-api
 - release
 - service-manual-frontend
 - service-manual-publisher


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Depends on several PRs:

* Publishing api PRs to remove legacy / unused endpoints (various)
* [Add PR template](https://github.com/alphagov/publishing-api/pull/2098) to publishing api 
* [Require prod access for merging](https://github.com/alphagov/govuk-saas-config/pull/115) in saas-config
* [Enable CD in puppet](https://github.com/alphagov/govuk-puppet/pull/11724)

[Trello card](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)
