### PR TITLE
Remove manuals-frontend from CD list

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -21,7 +21,6 @@
 - info-frontend
 - local-links-manager
 - locations-api
-- manuals-frontend
 - manuals-publisher
 - maslow
 - publisher


### PR DESCRIPTION
manuals-frontend is now retired, remove from the continuously deployed apps list.

https://trello.com/c/OtjBZRjL/1131-manuals-deprecate-manuals-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
