### PR TITLE
Add asset manager to continuously deployed apps

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -1,4 +1,5 @@
 - account-api
+- asset-manager
 - authenticating-proxy
 - bouncer
 - cache-clearing-service


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Requires merging first: 

* Pact tests and smokey tagging (various)
* [Add PR template](https://github.com/alphagov/asset-manager/pull/927) to asset manager 
* [Require prod access for merging PRs](https://github.com/alphagov/govuk-saas-config/pull/118)
* [Enable CD in govuk-puppet](https://github.com/alphagov/govuk-puppet/pull/11732)

[Ticket](https://trello.com/c/Sj4UTatV/126-enable-continuous-deployment-for-asset-manager)
