### PR TITLE
Switch side of badger image to improve accessibility

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -62,10 +62,6 @@
 } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <img title="Obey the Badger of Deploy" src="<%= asset_path('obey.jpg') %>" alt="Obey the Badger of Deploy" width="229" height="320">
-  </div>
-
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Deploy to Staging",
@@ -127,5 +123,9 @@
       <a target="_blank" href="<%= smokey_url(@application, "production") %>" class="govuk-link">Production smokey</a>:
       Run Smokey in Production and check your deploy didn't cause any problems.
     </p>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <img title="Obey the Badger of Deploy" src="<%= asset_path('obey.jpg') %>" alt="Obey the Badger of Deploy" width="229" height="320">
   </div>
 </div>


### PR DESCRIPTION
Swapping the side of the badger image on release pages to improve  for screen magnifiers. User accessibility testing for other GOV.UK interfaces has shown that screen magnifier user find it difficult when they have to scroll left to right to follow content. Having the badge image on the left, means users may miss the deployment buttons to right of it if zoomed in.

Old:
![image](https://user-images.githubusercontent.com/11051676/188487401-c5df423f-c4a3-4e75-95e3-dcfcad88a28f.png)

New:
![image](https://user-images.githubusercontent.com/11051676/188487587-0af92411-bbae-4401-81e6-11cf7294fc4d.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
