### PR TITLE
Rename release pages title and headings

### DIFF
--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, @application.name %>
+<% content_for :page_title, "#{@release_tag} - #{@application.name}" %>
 
 <div class="release__application-header">
   <%= render "govuk_publishing_components/components/breadcrumbs", {
@@ -6,14 +6,14 @@
       root_crumb,
       application_node_crumb(application: @application),
       {
-        title: "Deploy #{@application.name}"
+        title: "Deploy #{@release_tag}"
       }
     ]
   } %>
 
   <%= render "govuk_publishing_components/components/title", {
-    title: "Deploy #{@application.name}",
-    context: @application.shortname,
+    title: "Deploy #{@release_tag}",
+    context: @application.name,
     margin_bottom: 2
   } %>
   <%= render partial: "shared/badges", locals: { application: @application } %>
@@ -22,7 +22,7 @@
 <%= render 'status_notes', application: @application %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: "Candidate Release: #{@release_tag}",
+  text: "Release changes",
   margin_bottom: 4
 } %>
 

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -21,11 +21,6 @@
 
 <%= render 'status_notes', application: @application %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Release changes",
-  margin_bottom: 4
-} %>
-
 <% if @production_deploy %>
   <p class="govuk-body">Production is on <%= @production_deploy.version %> &mdash; deployed at <%= human_datetime(@production_deploy.created_at) %></p>
 <% else %>
@@ -33,6 +28,11 @@
 <% end %>
 
 <% if @production_deploy %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Release changes",
+    margin_bottom: 4
+  } %>
+
   <div class="release__view-diff">
     <%= render "govuk_publishing_components/components/button", {
       text: "View full diff",
@@ -55,11 +55,6 @@
     <% end %>
   <% end %>
 <% end %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Deploy",
-  margin_bottom: 4
-} %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
@@ -129,3 +124,4 @@
     </p>
   </div>
 </div>
+

--- a/app/views/shared/_application_header.html.erb
+++ b/app/views/shared/_application_header.html.erb
@@ -4,7 +4,7 @@
   } %>
 
   <%= render "govuk_publishing_components/components/title", {
-    title: "Deploy #{application.name}",
+    title: "#{application.name}",
     context: application.shortname,
     margin_bottom: 2
   } %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -96,7 +96,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
     should "show the application name" do
       get :show, params: { id: @app.id }
-      assert_select ".gem-c-title .gem-c-title__text", text: "Deploy #{@app.name}"
+      assert_select ".gem-c-title .gem-c-title__text", text: @app.name
     end
 
     should "show the application shortname" do
@@ -155,7 +155,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
       should "show the application" do
         get :show, params: { id: @app.id }
-        assert_select ".gem-c-title .gem-c-title__text", text: "Deploy #{@app.name}"
+        assert_select ".gem-c-title .gem-c-title__text", text: @app.name
       end
 
       should "set the commit history in reverse order" do
@@ -335,14 +335,14 @@ class ApplicationsControllerTest < ActionController::TestCase
         .returns("https://grafana_hostname")
     end
 
-    should "show that we are trying to deploy the application" do
+    should "show that we are trying to deploy the release" do
       get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select ".gem-c-title .gem-c-title__text", "Deploy #{@app.name}"
+      assert_select ".gem-c-title .gem-c-title__text", "Deploy #{@release_tag}"
+      assert_select ".gem-c-title .gem-c-title__context", text: @app.name
     end
 
     should "indicate which releases are current and about to be deployed" do
       get :deploy, params: { id: @app.id, tag: @release_tag }
-      assert_select ".gem-c-heading", "Candidate Release: #{@release_tag}"
       assert_select ".govuk-body", "Production is on #{@deployment.version} — deployed at 11am on 18 Jan 2013"
     end
 


### PR DESCRIPTION
This updates the html title, h1 heading and breadcrumbs to reference the release. This is more consistent as the page represents the release, changes associated with that release and what actions can be taken for a release. This make more logic sense as you don't just deploy an application, specifically you deploy a release of an application. This should also help screen reader users better understand the navigation of application as you can better tell the difference between an application page and a release page.

Old:
![image](https://user-images.githubusercontent.com/11051676/188492418-3c609891-e06a-4ede-858a-8e53889a720d.png)
![image](https://user-images.githubusercontent.com/11051676/188492434-f70ad1c8-58f1-4c60-bad5-75efe70e54e2.png)



New:
![image](https://user-images.githubusercontent.com/11051676/188492224-183c9de3-8e29-4980-9db9-a091ff85ca36.png)
![image](https://user-images.githubusercontent.com/11051676/188492308-10e50aaf-7a07-4464-a392-a67d9f24c1dc.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
