### PR TITLE
Add signon to continuously deployed apps

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -34,6 +34,7 @@
 - service-manual-publisher
 - short-url-manager
 - sidekiq-monitoring
+- signon
 - smartanswers
 - specialist-publisher
 - support


### PR DESCRIPTION
Do not merge yet, depends on:

* [Enable CD for signon in puppet](https://github.com/alphagov/govuk-puppet/pull/11825)
* [Require production access to merge publishing api](https://github.com/alphagov/govuk-saas-config/pull/124)
* [Adding PR template](https://github.com/alphagov/signon/pull/1960)
* which in turn depends on various PRs to increase test coverage

[Trello](https://trello.com/c/jBtHWHBh/14-enable-continuous-deployment-for-signon)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
