### PR TITLE
Remove "Continuously deployed" tag

### DIFF
--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -2,8 +2,6 @@
   <span class="release__badge release__badge--red">Automatic deployments disabled</span>
 <% end %>
 
-<% if application.cd_enabled? %>
-  <span class="release__badge">Continuously deployed</span>
-<% else %>
+<% unless application.cd_enabled? %>
   <span class="release__badge release__badge--orange">Manually deployed</span>
 <% end %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -104,16 +104,9 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select ".gem-c-title .gem-c-title__context", text: @app.shortname
     end
 
-    should "show the CD status" do
+    should "show manual deployed status" do
       get :show, params: { id: @app.id }
       assert_select ".release__badge--orange", "Manually deployed"
-      assert_select ".release__badge", { text: "Continuously deployed", count: 0 }
-
-      Application.stub :cd_statuses, { @app.shortname => { continuously_deployed: true } } do
-        get :show, params: { id: @app.id }
-        assert_select ".release__badge", "Continuously deployed"
-        assert_select ".release__badge--orange", false
-      end
     end
 
     should "show the deployment freeze badge" do


### PR DESCRIPTION
This removes the "Continuously deployed" to reduce noise and visual elements on the application list page. Most GOV.UK apps have been continuously deployed for some time. The "Manually deployed" tag remains, so users still can recognize which apps need to be deployed manually.

Before:
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/11051676/192556919-eb2e1853-3231-425c-a116-07c8530e1da6.png">


After:
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/11051676/192556786-56d6426c-f222-4f5c-a82e-d0b8e5d578e3.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
