### PR TITLE
Add Link Checker API to list of continuously deployed apps

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -23,6 +23,7 @@
 - hmrc-manuals-api
 - imminence
 - info-frontend
+- link-checker-api
 - local-links-manager
 - locations-api
 - manuals-publisher


### PR DESCRIPTION
Link Checker API is now continuously deployed so needs to be added this this list.

[Trello card](https://trello.com/c/xyWyqqhq/15-enable-continuous-deployment-for-link-checker-api)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
