### PR TITLE
Remove on_aws attribute

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -37,7 +37,7 @@ class ApplicationsController < ApplicationController
           @latest_deploy_to_each_environment_by_version[deployment.version] << deployment
         end
 
-        @production_deploy = @application.deployments.last_deploy_to production_environment_name
+        @production_deploy = @application.deployments.last_deploy_to "production"
         if @production_deploy
           comparison = Services.github.compare(
             @application.repo,
@@ -75,7 +75,7 @@ class ApplicationsController < ApplicationController
   def deploy
     @release_tag = params[:tag]
 
-    @production_deploy = @application.deployments.last_deploy_to production_environment_name
+    @production_deploy = @application.deployments.last_deploy_to "production"
 
     if @production_deploy
       comparison = Services.github.compare(
@@ -136,16 +136,7 @@ private
       :shortname,
       :status_notes,
       :task,
-      :on_aws,
       :deploy_freeze,
     )
-  end
-
-  def production_environment_name
-    if @application.on_aws?
-      "production-aws"
-    else
-      "production"
-    end
   end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -3,7 +3,7 @@ class ApplicationsController < ApplicationController
 
   include ActionView::Helpers::DateHelper
 
-  ENVIRONMENTS = %w[production staging integration].freeze
+  ENVIRONMENTS = %w[production-aws staging-aws integration].freeze
 
   def index
     @applications = Application.where(archived: false)
@@ -37,7 +37,7 @@ class ApplicationsController < ApplicationController
           @latest_deploy_to_each_environment_by_version[deployment.version] << deployment
         end
 
-        @production_deploy = @application.deployments.last_deploy_to "production"
+        @production_deploy = @application.deployments.last_deploy_to "production-aws"
         if @production_deploy
           comparison = Services.github.compare(
             @application.repo,
@@ -75,7 +75,7 @@ class ApplicationsController < ApplicationController
   def deploy
     @release_tag = params[:tag]
 
-    @production_deploy = @application.deployments.last_deploy_to "production"
+    @production_deploy = @application.deployments.last_deploy_to "production-aws"
 
     if @production_deploy
       comparison = Services.github.compare(

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,11 +1,11 @@
 module UrlHelper
   def dashboard_url(application, environment)
-    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    suffix = govuk_domain_suffix(environment)
     "https://grafana.#{suffix}/dashboard/file/#{application.shortname}.json"
   end
 
-  def smokey_url(application, environment)
-    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+  def smokey_url(environment)
+    suffix = govuk_domain_suffix(environment)
     "https://deploy.#{suffix}/job/Smokey"
   end
 
@@ -21,20 +21,16 @@ module UrlHelper
     "#{application.repo_url}/compare/#{deploy.version}...#{application.default_branch}"
   end
 
-  def govuk_domain_suffix(environment, on_aws:)
+  def govuk_domain_suffix(environment)
     if environment == "integration"
       "integration.publishing.service.gov.uk"
-    elsif on_aws
-      "blue.#{environment}.govuk.digital"
-    elsif environment == "production"
-      "publishing.service.gov.uk"
     else
-      "#{environment}.publishing.service.gov.uk"
+      "blue.#{environment}.govuk.digital"
     end
   end
 
   def jenkins_deploy_url(application, release_tag, environment)
-    suffix = govuk_domain_suffix(environment, on_aws: application.on_aws?)
+    suffix = govuk_domain_suffix(environment)
     job_name = application.shortname == "puppet" ? "Deploy_Puppet" : "Deploy_App"
     escaped_release_tag = CGI.escape(release_tag)
     "https://deploy.#{suffix}/job/#{job_name}/parambuild?TARGET_APPLICATION=#{application.shortname}&TAG=#{escaped_release_tag}".html_safe

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -67,11 +67,7 @@ class Application < ApplicationRecord
   end
 
   def production_and_staging_environments
-    if on_aws?
-      %w[production-aws staging-aws]
-    else
-      %w[production staging]
-    end
+    %w[production-aws staging-aws]
   end
 
   def self.cd_statuses

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -42,10 +42,8 @@ class Application < ApplicationRecord
   end
 
   def status
-    return :production_and_staging_not_in_sync unless in_sync?(production_and_staging_environments)
-    return :undeployed_changes_in_integration unless in_sync?(
-      production_and_staging_environments + %w[integration],
-    )
+    return :production_and_staging_not_in_sync unless in_sync?(%w[production-aws staging-aws])
+    return :undeployed_changes_in_integration unless in_sync?(%w[production-aws staging-aws integration])
 
     :all_environments_match
   end
@@ -64,10 +62,6 @@ class Application < ApplicationRecord
 
   def repo_tag_url(tag)
     "https://github.com/#{repo}/releases/tag/#{tag}"
-  end
-
-  def production_and_staging_environments
-    %w[production-aws staging-aws]
   end
 
   def self.cd_statuses

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -44,7 +44,7 @@ private
   # Record the deployment to statsd and thence to graphite
   def record_to_statsd
     # Only record production deployments in production graphite
-    if environment == "production" || environment == "production-aws"
+    if environment == "production-aws"
       key = "deploys.#{application.shortname}"
       GovukStatsd.increment(key)
     end

--- a/app/models/deployment_stats.rb
+++ b/app/models/deployment_stats.rb
@@ -22,7 +22,7 @@ private
 
   def production_deploys
     @production_deploys ||= initial_scope
-      .where(environment: %w[production production-aws])
+      .where(environment: "production-aws")
       .joins(:application)
       .order("deployments.created_at ASC")
   end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -3,6 +3,5 @@ class ApplicationSerializer < ActiveModel::Serializer
   attribute :status_notes, key: :notes
   attribute :repo_url, key: :repository_url
   attribute :default_branch, key: :repository_default_branch
-  attribute :on_aws, key: :hosted_on_aws
   attribute :cd_enabled?, key: :continuously_deployed
 end

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -44,8 +44,7 @@
           <%= t.cell application_status %>
 
           <% @environments.each do |environment| %>
-            <% environment_name = (application.on_aws? && environment != "integration") ? "#{environment}-aws" : environment %>
-            <% latest_deploy = application.latest_deploy_to_each_environment[environment_name] %>
+            <% latest_deploy = application.latest_deploy_to_each_environment[environment] %>
             <% env_deploy = capture do %>
               <% if latest_deploy %>
                 <p class="govuk-body-s govuk-!-margin-bottom-1"><%= github_tag_link_to(application, latest_deploy.version) %></p>

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -64,18 +64,6 @@
     ]
   } %>
 
-  <input type="hidden" name="application[on_aws]" value="0" />
-  <%= render "govuk_publishing_components/components/checkboxes", {
-    name: "application[on_aws]",
-    items: [
-      {
-        label: "Deployed to AWS?",
-        value: "1",
-        checked: @application.on_aws?
-      }
-    ]
-  } %>
-
   <input type="hidden" name="application[deploy_freeze]" value="0" />
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "application[deploy_freeze]",

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -70,7 +70,7 @@
     </p>
     <p class="govuk-body">
       <%= octicon "cpu", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-      <a target="_blank" href="<%= smokey_url(@application, "integration") %>" class="govuk-link">Integration smokey</a>:
+      <a target="_blank" href="<%= smokey_url("integration") %>" class="govuk-link">Integration smokey</a>:
       Run Smokey in Integration and check your deploy didn't cause any problems.
     </p>
     <%= render "govuk_publishing_components/components/button", {
@@ -92,7 +92,7 @@
     </p>
     <p class="govuk-body">
       <%= octicon "cpu", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-      <a target="_blank" href="<%= smokey_url(@application, "staging") %>" class="govuk-link">Staging smokey</a>:
+      <a target="_blank" href="<%= smokey_url("staging") %>" class="govuk-link">Staging smokey</a>:
       Run Smokey in Staging and check your deploy didn't cause any problems.
     </p>
     <%= render "govuk_publishing_components/components/button", {
@@ -115,7 +115,7 @@
     </p>
     <p class="govuk-body">
       <%= octicon "cpu", height: '20px', style: "vertical-align: middle; margin-right: 4px;", "aria-hidden": "true" %>
-      <a target="_blank" href="<%= smokey_url(@application, "production") %>" class="govuk-link">Production smokey</a>:
+      <a target="_blank" href="<%= smokey_url("production") %>" class="govuk-link">Production smokey</a>:
       Run Smokey in Production and check your deploy didn't cause any problems.
     </p>
   </div>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -37,7 +37,7 @@
                   <% if deployments = @latest_deploy_to_each_environment_by_version[tag[:name]] %>
                     <% deployments.each do |deployment| %>
                       <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
-                        <span class="release__commits-label release__commits-label--<%= 'production' if ['production', 'production-aws'].include?(deployment.environment) %>"><%= deployment.environment.humanize %></span>
+                        <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production-aws" %>"><%= deployment.environment.humanize %></span>
                         <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
                       </p>
                     <% end %>

--- a/db/migrate/20220923151609_change_on_aws_column_name.rb
+++ b/db/migrate/20220923151609_change_on_aws_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeOnAwsColumnName < ActiveRecord::Migration[7.0]
+  def change
+    remove_column(:applications, :on_aws, type: :boolean)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_03_19_081818) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_23_151609) do
   create_table "applications", id: :integer, charset: "latin1", force: :cascade do |t|
     t.string "name"
     t.string "repo"
@@ -19,7 +19,6 @@ ActiveRecord::Schema[7.0].define(version: 2021_03_19_081818) do
     t.string "status_notes"
     t.string "shortname"
     t.boolean "archived", default: false, null: false
-    t.boolean "on_aws", default: false, null: false
     t.boolean "deploy_freeze", default: false, null: false
     t.string "default_branch", default: "main", null: false
     t.index ["name"], name: "index_applications_on_name", unique: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,6 @@ Examples:
    "deploy_freeze": true,
    "notes": "",
    "repository_url": "https://github.com/alphagov/smart-answers",
-   "hosted_on_aws": true
 }
 ```
 

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
   factory :deployment do
     sequence(:version) { |n| "release_#{n}" }
-    environment { "production" }
+    environment { "production-aws" }
   end
 
   factory :user do

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -13,7 +13,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       @deploy1 = FactoryBot.create(
         :deployment,
         application: @app1,
-        environment: "staging",
+        environment: "staging-aws",
         version: "release_x",
       )
     end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -77,12 +77,6 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_equal false, application.archived
     end
 
-    should "default to not being on AWS" do
-      application = Application.new(@atts)
-
-      assert_equal false, application.on_aws?
-    end
-
     should "default to not be in deploy freeze" do
       application = Application.new(@atts)
 

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -8,14 +8,14 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
 
       # Don't include deploys from this month (it skews the graph)
-      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production-aws")
 
       # Don't include staging deploys
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
 
-      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "production")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
 
       expected = {
@@ -36,13 +36,13 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       # Don't include staging deploys
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
 
-      FactoryBot.create(:deployment, created_at: "2016-01-01", application: app, environment: "production")
-      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
-      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2016-01-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
       FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
 
       # Do include deploys from this year
-      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production-aws")
 
       expected = {
         2016 => 1,
@@ -62,9 +62,9 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
 
       # Don't include other apps' deployments
-      FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production-aws")
 
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
 
       expected = {


### PR DESCRIPTION
This PR is to simplify the codebase by removing code used to differentiate between Carrenza and AWS environments. This an artefact from the migration, however that migration is now complete and all applications are deployed to AWS.

This normalises the production and staging environment names with "-aws" suffix. Which can be removed in later PR, however remains for now as deployments from Jenkins are still registered with the suffix.

This removes the "hosted_on_aws" from the deployment API response, but this isn't used by anything.

This PR is scoped to removing the logic differences between deployments for Carrenza or AWS. After this PR, I'll raise another PR to make the environment name consistent i.e. production, staging and integration (dropping the -aws). But can't raise that until, this PR is merged. As part of dropping the -aws suffix, I will also merge the [change to app-deployments](https://github.com/alphagov/govuk-app-deployment/pull/453/files) so new deployments also don't use the -aws suffix.

TLDR; will ultimately end up with production, staging and integration - but just need to this as preliminary work, so I don't break Release and introduce too much downtime.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
