### PR TITLE
Remove "-aws" suffix from envrionment names

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -3,7 +3,7 @@ class ApplicationsController < ApplicationController
 
   include ActionView::Helpers::DateHelper
 
-  ENVIRONMENTS = %w[production-aws staging-aws integration].freeze
+  ENVIRONMENTS = %w[production staging integration].freeze
 
   def index
     @applications = Application.where(archived: false)
@@ -37,7 +37,7 @@ class ApplicationsController < ApplicationController
           @latest_deploy_to_each_environment_by_version[deployment.version] << deployment
         end
 
-        @production_deploy = @application.deployments.last_deploy_to "production-aws"
+        @production_deploy = @application.deployments.last_deploy_to "production"
         if @production_deploy
           comparison = Services.github.compare(
             @application.repo,
@@ -75,7 +75,7 @@ class ApplicationsController < ApplicationController
   def deploy
     @release_tag = params[:tag]
 
-    @production_deploy = @application.deployments.last_deploy_to "production-aws"
+    @production_deploy = @application.deployments.last_deploy_to "production"
 
     if @production_deploy
       comparison = Services.github.compare(

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -42,8 +42,8 @@ class Application < ApplicationRecord
   end
 
   def status
-    return :production_and_staging_not_in_sync unless in_sync?(%w[production-aws staging-aws])
-    return :undeployed_changes_in_integration unless in_sync?(%w[production-aws staging-aws integration])
+    return :production_and_staging_not_in_sync unless in_sync?(%w[production staging])
+    return :undeployed_changes_in_integration unless in_sync?(%w[production staging integration])
 
     :all_environments_match
   end

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -44,7 +44,7 @@ private
   # Record the deployment to statsd and thence to graphite
   def record_to_statsd
     # Only record production deployments in production graphite
-    if environment == "production-aws"
+    if environment == "production"
       key = "deploys.#{application.shortname}"
       GovukStatsd.increment(key)
     end

--- a/app/models/deployment_stats.rb
+++ b/app/models/deployment_stats.rb
@@ -22,7 +22,7 @@ private
 
   def production_deploys
     @production_deploys ||= initial_scope
-      .where(environment: "production-aws")
+      .where(environment: "production")
       .joins(:application)
       .order("deployments.created_at ASC")
   end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -37,7 +37,7 @@
                   <% if deployments = @latest_deploy_to_each_environment_by_version[tag[:name]] %>
                     <% deployments.each do |deployment| %>
                       <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
-                        <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production-aws" %>"><%= deployment.environment.humanize %></span>
+                        <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
                         <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
                       </p>
                     <% end %>

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
   factory :deployment do
     sequence(:version) { |n| "release_#{n}" }
-    environment { "production-aws" }
+    environment { "production" }
   end
 
   factory :user do

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -13,7 +13,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       @deploy1 = FactoryBot.create(
         :deployment,
         application: @app1,
-        environment: "staging-aws",
+        environment: "staging",
         version: "release_x",
       )
     end

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -8,15 +8,15 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
 
       # Don't include deploys from this month (it skews the graph)
-      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
 
       # Don't include staging deploys
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
 
-      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
 
       expected = {
         "2018-01" => 1,
@@ -36,13 +36,13 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       # Don't include staging deploys
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
 
-      FactoryBot.create(:deployment, created_at: "2016-01-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2016-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2017-01-01", application: app, environment: "production")
 
       # Do include deploys from this year
-      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
 
       expected = {
         2016 => 1,
@@ -62,10 +62,10 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
 
       # Don't include other apps' deployments
-      FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production")
 
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
-      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production-aws")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
+      FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
 
       expected = {
         "2018-02" => 2,


### PR DESCRIPTION
This removes the "-aws" suffix from the staging and production environment names. This is an artefact from the migration between Carrenza and AWS. This migration is now complete and we don't need to distingushed between them and we know all application and environments are in AWS.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
