### PR TITLE
Mark Transition as continuously deployed

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -40,5 +40,6 @@
 - specialist-publisher
 - support
 - support-api
+- transition
 - travel-advice-publisher
 - whitehall


### PR DESCRIPTION
Once https://github.com/alphagov/govuk-puppet/pull/11889 is merged and deployed, Transition will be continuously deployed.

[Trello card](https://trello.com/c/VgRHbI98)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
