### PR TITLE
Update Node.js to version 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
       # base dependencies
       ruby-dev build-essential libgmp3-dev default-libmysqlclient-dev \
       # for bundle exec rake -T and assets commands to work
-      nodejs \
+      curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+      apt-get update -qq && apt-get install -y nodejs \
       # for healthcheck
       curl \
       yarn


### PR DESCRIPTION
The current version is not supported anymore.

https://trello.com/c/PMsAXSoT/3029-review-govuks-usage-of-node-2
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
