### PR TITLE
Simplify logic for applications deployments view

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -25,7 +25,7 @@ class ApplicationsController < ApplicationController
       format.html do
         @outstanding_dependency_pull_requests = @application.dependency_pull_requests[:total_count]
 
-        @tags_by_commit = @application.tags_by_commit
+        @tag_names_by_commit = @application.tag_names_by_commit
 
         # where version == git tag, which it isn't for licensify
         @latest_deploy_to_each_environment_by_version = {}

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -27,13 +27,6 @@ class ApplicationsController < ApplicationController
 
         @tag_names_by_commit = @application.tag_names_by_commit
 
-        # where version == git tag, which it isn't for licensify
-        @latest_deploy_to_each_environment_by_version = {}
-        @application.latest_deploy_to_each_environment.each_value do |deployment|
-          @latest_deploy_to_each_environment_by_version[deployment.version] ||= []
-          @latest_deploy_to_each_environment_by_version[deployment.version] << deployment
-        end
-
         @commits = if @application.deployments.last_deploy_to("production")
                      @application.undeployed_commits
                    else

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,13 +23,10 @@ class ApplicationsController < ApplicationController
     respond_to do |format|
       format.json { render json: @application }
       format.html do
-        @outstanding_dependency_pull_requests = Services.github.search_issues("repo:#{@application.repo} is:pr state:open label:dependencies")[:total_count]
+        @outstanding_dependency_pull_requests = @application.dependency_pull_requests[:total_count]
 
-        @tags_by_commit = Services.github.tags(@application.repo).each_with_object({}) do |tag, hash|
-          sha = tag[:commit][:sha]
-          hash[sha] ||= []
-          hash[sha] << tag
-        end
+        @tags_by_commit = @application.tags_by_commit
+
         # where version == git tag, which it isn't for licensify
         @latest_deploy_to_each_environment_by_version = {}
         @application.latest_deploy_to_each_environment.each_value do |deployment|
@@ -37,19 +34,11 @@ class ApplicationsController < ApplicationController
           @latest_deploy_to_each_environment_by_version[deployment.version] << deployment
         end
 
-        @production_deploy = @application.deployments.last_deploy_to "production"
-        if @production_deploy
-          comparison = Services.github.compare(
-            @application.repo,
-            @production_deploy.version,
-            @application.default_branch,
-          )
-          # The `compare` API shows commits in forward chronological order
-          @commits = comparison.commits.reverse + [comparison.base_commit]
-        else
-          # the `commits` API shows commits in reverse chronological order
-          @commits = Services.github.commits(@application.repo)
-        end
+        @commits = if @application.deployments.last_deploy_to("production")
+                     @application.undeployed_commits
+                   else
+                     @application.commits
+                   end
 
         @github_available = true
       rescue Octokit::TooManyRequests

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -72,4 +72,38 @@ class Application < ApplicationRecord
     key = shortname || fallback_shortname
     Application.cd_statuses.include? key
   end
+
+  def dependency_pull_requests
+    Services.github.search_issues("repo:#{repo} is:pr state:open label:dependencies")
+  end
+
+  def commits
+    Services.github.commits(repo)
+  end
+
+  def tags_by_commit
+    tags.each_with_object({}) do |tag, hash|
+      sha = tag[:commit][:sha]
+      hash[sha] ||= []
+      hash[sha] << tag
+    end
+  end
+
+  def undeployed_commits
+    production_deployment = deployments.last_deploy_to("production")
+
+    comparison = Services.github.compare(
+      repo,
+      production_deployment.version,
+      default_branch,
+    )
+    # The `compare` API shows commits in forward chronological order
+    comparison.commits.reverse + [comparison.base_commit]
+  end
+
+private
+
+  def tags
+    Services.github.tags(repo)
+  end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -81,11 +81,11 @@ class Application < ApplicationRecord
     Services.github.commits(repo)
   end
 
-  def tags_by_commit
+  def tag_names_by_commit
     tags.each_with_object({}) do |tag, hash|
       sha = tag[:commit][:sha]
       hash[sha] ||= []
-      hash[sha] << tag
+      hash[sha] << tag[:name]
     end
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -82,6 +82,8 @@ class Application < ApplicationRecord
   end
 
   def tag_names_by_commit
+    tags = Services.github.tags(repo)
+
     tags.each_with_object({}) do |tag, hash|
       sha = tag[:commit][:sha]
       hash[sha] ||= []
@@ -99,11 +101,5 @@ class Application < ApplicationRecord
     )
     # The `compare` API shows commits in forward chronological order
     comparison.commits.reverse + [comparison.base_commit]
-  end
-
-private
-
-  def tags
-    Services.github.tags(repo)
   end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -30,31 +30,25 @@
       <%= t.body do %>
         <% @commits.each do |commit| %>
           <%= t.row do %>
-            <% tags = @tag_names_by_commit[commit[:sha]] %>
+            <% tags = @tag_names_by_commit.fetch(commit[:sha], []) %>
             <% commit_deployments = capture do %>
-              <% if tags %>
-                <% tags.each do |tag| %>
-                  <% if deployments = @latest_deploy_to_each_environment_by_version[tag] %>
-                    <% deployments.each do |deployment| %>
-                      <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
-                        <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
-                        <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
-                      </p>
-                    <% end %>
+              <% tags.each do |tag| %>
+                <% if deployments = @latest_deploy_to_each_environment_by_version[tag] %>
+                  <% deployments.each do |deployment| %>
+                    <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
+                      <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
+                      <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
+                    </p>
                   <% end %>
                 <% end %>
-              <% else %>
-
               <% end %>
             <% end %>
 
             <%= t.cell commit_deployments || "" %>
 
             <% commit_tags = capture do %>
-              <% if tags %>
-                <% tags.each do |tag| %>
-                  <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
-                <% end %>
+              <% tags.each do |tag| %>
+                <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
               <% end %>
             <% end %>
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -30,11 +30,11 @@
       <%= t.body do %>
         <% @commits.each do |commit| %>
           <%= t.row do %>
-            <% tags = @tags_by_commit[commit[:sha]] %>
+            <% tags = @tag_names_by_commit[commit[:sha]] %>
             <% commit_deployments = capture do %>
               <% if tags %>
                 <% tags.each do |tag| %>
-                  <% if deployments = @latest_deploy_to_each_environment_by_version[tag[:name]] %>
+                  <% if deployments = @latest_deploy_to_each_environment_by_version[tag] %>
                     <% deployments.each do |deployment| %>
                       <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
                         <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
@@ -53,7 +53,7 @@
             <% commit_tags = capture do %>
               <% if tags %>
                 <% tags.each do |tag| %>
-                  <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag[:name] %>"><%= tag[:name] %></a>
+                  <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -32,14 +32,12 @@
           <%= t.row do %>
             <% tags = @tag_names_by_commit.fetch(commit[:sha], []) %>
             <% commit_deployments = capture do %>
-              <% tags.each do |tag| %>
-                <% if deployments = @latest_deploy_to_each_environment_by_version[tag] %>
-                  <% deployments.each do |deployment| %>
-                    <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
-                      <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
-                      <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
-                    </p>
-                  <% end %>
+              <% @application.latest_deploy_to_each_environment.each do |_, deployment| %>
+                <% if tags.include?(deployment.version) %>
+                  <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
+                    <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
+                    <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
+                  </p>
                 <% end %>
               <% end %>
             <% end %>


### PR DESCRIPTION
This PR is a pre-cursor refactor to enable EKS deployments to be shown in Release. 

This PR:
- moves a lot of logic from the controller method into individual model methods (that are easier to read and unit test). 
- refactors the logic to calculate which deployments should be shown in the "deployed_to" column. This will make it easier to extend the logic so we can show deployments the match the commit SHA, rather than just a tag (which we don't have available in EKS deployment pipelines)


