### PR TITLE
Remove jquery

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,3 @@
-//= require jquery/dist/jquery
 //= require_tree .
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components

--- a/app/assets/javascripts/release.js
+++ b/app/assets/javascripts/release.js
@@ -1,20 +1,25 @@
-$(function () {
-  var applicationsFilterInput = $("input[name='applications-filter']")
-  var applicationsFilterRows = $('[data-filter-applications]').find('.govuk-table__body .govuk-table__row')
+var ready = function (callback) {
+  if (document.readyState !== 'loading') callback()
+  else document.addEventListener('DOMContentLoaded', callback)
+}
 
-  applicationsFilterInput.on('keyup', function (e) {
-    var searchTerm = e.target.value
+ready(function () {
+  var applicationsFilterInput = document.querySelector("input[name='applications-filter']")
+  var applicationsFilterRows = document.querySelectorAll('[data-filter-applications] .govuk-table__body > .govuk-table__row')
 
-    applicationsFilterRows.not(function () {
-      var currentApplication = $(this)
-      var currentApplicationLink = currentApplication.find('[data-filter-applications-link]')
-      var currentApplicationText = currentApplicationLink.text()
+  if (applicationsFilterInput) {
+    applicationsFilterInput.addEventListener('keyup', function (e) {
+      var searchTerm = e.target.value.toLowerCase()
 
-      currentApplication.removeClass('js-hidden')
+      applicationsFilterRows.forEach(function (row) {
+        var appName = row.querySelector('[data-filter-applications-link]').textContent
 
-      if (currentApplicationText.toLowerCase().includes(searchTerm)) {
-        return true
-      }
-    }).addClass('js-hidden')
-  })
+        if (appName.toLowerCase().includes(searchTerm)) {
+          row.classList.remove('js-hidden')
+        } else {
+          row.classList.add('js-hidden')
+        }
+      })
+    })
+  }
 })

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "standardx": {
     "env": {
-      "browser": true,
-      "jquery": true
+      "browser": true
     }
   },
   "eslintConfig": {
@@ -23,9 +22,7 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
-  "dependencies": {
-    "jquery": "3.6.3"
-  },  
+  "dependencies": {},  
   "devDependencies": {
     "standardx": "^7.0.0",
     "stylelint": "^14.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,11 +1076,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-jquery@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.3.tgz#23ed2ffed8a19e048814f13391a19afcdba160e6"
-  integrity sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
This removes the need for the jquery and the dependency. We only used it to implement the application filter, which can easily be written with Vanilla JS.