### PR TITLE
Dockerfile cleanup + enable bootsnap

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.dockerignore
+.git
+.github
+.gitignore
+Dockerfile
+Jenkinsfile
+Procfile
+README.md
+coverage
+docs
+features
+log
+node_modules
+script
+spec
+test
+tmp

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.0.4"
 
 gem "active_model_serializers"
+gem "bootsnap", require: false
 gem "chartkick"
 gem "friendly_id"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.16.0)
+      msgpack (~> 1.2)
     brakeman (5.4.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -184,6 +186,7 @@ GEM
     minitest (5.17.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
+    msgpack (1.6.0)
     multi_xml (0.6.0)
     mysql2 (0.5.5)
     net-imap (0.3.4)
@@ -381,6 +384,7 @@ DEPENDENCIES
   active_model_serializers
   better_errors
   binding_of_caller
+  bootsnap
   brakeman
   byebug
   capybara

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,9 @@ module ReleaseApp
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/release"
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Use govuk-ruby-base image.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Add .dockerignore.