### PR TITLE
Show deployments that match commit SHA

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -39,6 +39,13 @@ class Deployment < ApplicationRecord
     application.repo_compare_url(previous_version, version)
   end
 
+  def commit_match?(sha)
+    commit_sha = deployed_sha || ""
+    return false if commit_sha.length < 6
+
+    sha.starts_with?(commit_sha)
+  end
+
 private
 
   # Record the deployment to statsd and thence to graphite

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -33,7 +33,7 @@
             <% tags = @tag_names_by_commit.fetch(commit[:sha], []) %>
             <% commit_deployments = capture do %>
               <% @application.latest_deploy_to_each_environment.each do |_, deployment| %>
-                <% if tags.include?(deployment.version) %>
+                <% if tags.include?(deployment.version) || deployment.commit_match?(commit[:sha]) %>
                   <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
                     <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
                     <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
   factory :deployment do
     sequence(:version) { |n| "release_#{n}" }
     environment { "production" }
+    application
   end
 
   factory :user do

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -13,4 +13,36 @@ class DeploymentTest < ActiveSupport::TestCase
       assert_equal previous, the_deploy.previous_deployment
     end
   end
+
+  describe "#commit_match?" do
+    should "return true when SHAs are the same" do
+      deployment = FactoryBot.create(:deployment, deployed_sha: "c579613e5f0335ecf409fed881fa7919c150c1af")
+
+      assert_equal true, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+    end
+
+    should "return false when SHAs are the different" do
+      deployment = FactoryBot.create(:deployment, deployed_sha: "0fa90a3bc5b1c91e9355de3507244e11d8a2d68c")
+
+      assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+    end
+
+    should "return true if deployed_sha is a short SHA" do
+      deployment = FactoryBot.create(:deployment, deployed_sha: "c579613")
+
+      assert_equal true, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+    end
+
+    should "return false if deployed_sha is nil" do
+      deployment = FactoryBot.create(:deployment, deployed_sha: nil)
+
+      assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+    end
+
+    should "return false if deployed_sha too short" do
+      deployment = FactoryBot.create(:deployment, deployed_sha: "c5")
+
+      assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+    end
+  end
 end


### PR DESCRIPTION
Previously deployments only were shown if the version match the git tag (e.g. release_xxxx). However in EKS we don't have the git tag information only the commit SHA.