### PR TITLE
Remove retired service-manual-frontend

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -31,7 +31,6 @@
 - publisher
 - publishing-api
 - release
-- service-manual-frontend
 - service-manual-publisher
 - short-url-manager
 - sidekiq-monitoring


### PR DESCRIPTION
https://trello.com/c/gICwB7Ej/1195-retire-service-manuals-frontend-app-m

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
