### PR TITLE
Use EKS environments as live environments 

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -27,7 +27,7 @@ class ApplicationsController < ApplicationController
 
         @tag_names_by_commit = @application.tag_names_by_commit
 
-        @commits = if @application.deployments.last_deploy_to("production")
+        @commits = if @application.deployments.last_deploy_to(@application.live_environment)
                      @application.undeployed_commits
                    else
                      @application.commits
@@ -57,7 +57,7 @@ class ApplicationsController < ApplicationController
   def deploy
     @release_tag = params[:tag]
 
-    @production_deploy = @application.deployments.last_deploy_to "production"
+    @production_deploy = @application.deployments.last_deploy_to(@application.live_environment)
 
     if @production_deploy
       comparison = Services.github.compare(

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -100,7 +100,7 @@ class Application < ApplicationRecord
   end
 
   def undeployed_commits
-    production_deployment = deployments.last_deploy_to("production")
+    production_deployment = deployments.last_deploy_to(live_environment)
 
     comparison = Services.github.compare(
       repo,

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -107,4 +107,12 @@ class Application < ApplicationRecord
     # The `compare` API shows commits in forward chronological order
     comparison.commits.reverse + [comparison.base_commit]
   end
+
+  def live_environment
+    if deployed_to_ec2?
+      "production"
+    else
+      "production EKS"
+    end
+  end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -42,8 +42,11 @@ class Application < ApplicationRecord
   end
 
   def status
-    return :production_and_staging_not_in_sync unless in_sync?(%w[production staging])
-    return :undeployed_changes_in_integration unless in_sync?(%w[production staging integration])
+    envs = %w[production staging integration]
+    envs = envs.map { |env| "#{env} EKS" } unless deployed_to_ec2?
+
+    return :production_and_staging_not_in_sync unless in_sync?(envs[0, 1])
+    return :undeployed_changes_in_integration unless in_sync?(envs)
 
     :all_environments_match
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -60,6 +60,10 @@ class Application < ApplicationRecord
     "https://github.com/#{repo}/compare/#{from}...#{to}"
   end
 
+  def self.ec2_deployed_apps
+    @ec2_deployed_apps ||= YAML.safe_load_file("data/ec2_deployed_apps.yml")
+  end
+
   def self.cd_statuses
     @cd_statuses ||= YAML.safe_load(open("data/continuously_deployed_apps.yml"))
   end
@@ -67,6 +71,11 @@ class Application < ApplicationRecord
   def cd_enabled?
     key = shortname || fallback_shortname
     Application.cd_statuses.include? key
+  end
+
+  def deployed_to_ec2?
+    key = shortname || fallback_shortname
+    Application.ec2_deployed_apps.include? key
   end
 
   def dependency_pull_requests

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -46,6 +46,10 @@ class Deployment < ApplicationRecord
     sha.starts_with?(commit_sha)
   end
 
+  def to_live_environment?
+    environment == application.live_environment
+  end
+
 private
 
   # Record the deployment to statsd and thence to graphite

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -44,6 +44,7 @@
           <%= t.cell application_status %>
 
           <% @environments.each do |environment| %>
+            <% environment = environment + " EKS" unless application.deployed_to_ec2? %>
             <% latest_deploy = application.latest_deploy_to_each_environment[environment] %>
             <% env_deploy = capture do %>
               <% if latest_deploy %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -35,7 +35,7 @@
               <% @application.latest_deploy_to_each_environment.each do |_, deployment| %>
                 <% if tags.include?(deployment.version) || deployment.commit_match?(commit[:sha]) %>
                   <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
-                    <span class="release__commits-label release__commits-label--<%= 'production' if deployment.environment == "production" %>"><%= deployment.environment.humanize %></span>
+                    <span class="release__commits-label release__commits-label--<%= 'production' if deployment.to_live_environment? %>"><%= deployment.environment.humanize %></span>
                     <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
                   </p>
                 <% end %>

--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -5,3 +5,7 @@
 <% unless application.cd_enabled? %>
   <span class="release__badge release__badge--orange">Manually deployed</span>
 <% end %>
+
+<% if application.deployed_to_ec2? %>
+  <span class="release__badge release__badge--red">Not migrated to EKS</span>
+<% end %>

--- a/data/ec2_deployed_apps.yml
+++ b/data/ec2_deployed_apps.yml
@@ -1,0 +1,9 @@
+- bouncer
+- ckan
+- govuk_crawler_worker
+- licensify
+- licensify-admin
+- licensify-feed
+- puppet
+- service-manual-frontend
+- sidekiq-monitoring

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
   factory :deployment do
     sequence(:version) { |n| "release_#{n}" }
-    environment { "production" }
+    environment { "production EKS" }
     application
   end
 

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -13,7 +13,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       @deploy1 = FactoryBot.create(
         :deployment,
         application: @app1,
-        environment: "staging",
+        environment: "staging EKS",
         version: "release_x",
       )
     end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -172,4 +172,33 @@ class ApplicationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "deployed to EC2" do
+    setup do
+      @atts = {
+        name: "Tron-o-matic",
+        repo: "alphagov/tron-o-matic",
+      }
+    end
+
+    context "when the application is not continuously deployed" do
+      should "return false" do
+        application = Application.new(@atts)
+
+        Application.stub :ec2_deployed_apps, ["something-other-than-tron-o-matic"] do
+          assert_not application.deployed_to_ec2?
+        end
+      end
+    end
+
+    context "when the application is continuously deployed" do
+      should "return true" do
+        application = Application.new(@atts)
+
+        Application.stub :ec2_deployed_apps, ["tron-o-matic"] do
+          assert application.deployed_to_ec2?
+        end
+      end
+    end
+  end
 end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -181,7 +181,7 @@ class ApplicationTest < ActiveSupport::TestCase
       }
     end
 
-    context "when the application is not continuously deployed" do
+    context "when the application is not deployed to EC2" do
       should "return false" do
         application = Application.new(@atts)
 
@@ -191,12 +191,41 @@ class ApplicationTest < ActiveSupport::TestCase
       end
     end
 
-    context "when the application is continuously deployed" do
+    context "when the application is deployed to EC2" do
       should "return true" do
         application = Application.new(@atts)
 
         Application.stub :ec2_deployed_apps, ["tron-o-matic"] do
           assert application.deployed_to_ec2?
+        end
+      end
+    end
+  end
+
+  context "live environment" do
+    setup do
+      @atts = {
+        name: "Tron-o-matic",
+        repo: "alphagov/tron-o-matic",
+      }
+    end
+
+    context "when the application is not deployed to EC2" do
+      should "returns production EKS" do
+        application = Application.new(@atts)
+
+        Application.stub :ec2_deployed_apps, ["something-other-than-tron-o-matic"] do
+          assert_equal "production EKS", application.live_environment
+        end
+      end
+    end
+
+    context "when the application is deployed to EC2" do
+      should "return production" do
+        application = Application.new(@atts)
+
+        Application.stub :ec2_deployed_apps, ["tron-o-matic"] do
+          assert_equal "production", application.live_environment
         end
       end
     end

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -45,4 +45,18 @@ class DeploymentTest < ActiveSupport::TestCase
       assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
   end
+
+  describe "#to_live_environment?" do
+    should "return true if deployment to application's live environment" do
+      deployment = FactoryBot.create(:deployment, environment: "production EKS")
+
+      assert_equal true, deployment.to_live_environment?
+    end
+
+    should "return false if deployment not to application's live environment" do
+      deployment = FactoryBot.create(:deployment, environment: "test")
+
+      assert_equal false, deployment.to_live_environment?
+    end
+  end
 end


### PR DESCRIPTION
This updates the Release app reference the EKS environments for information about deployments. 

Interface changes for EKS deployed apps include:
- making the "production EKS" environment label red, instead of "production"
- status column in the application table compares EKS version of prod, staging, integration
- git log follow EKS versions of prod, staging and integration

This also adds a badge to indicate which applications aren't yet deployed to EKS.