### PR TITLE
Remove bouncer for deployed to EC2 list

### DIFF
--- a/data/ec2_deployed_apps.yml
+++ b/data/ec2_deployed_apps.yml
@@ -1,4 +1,3 @@
-- bouncer
 - ckan
 - govuk_crawler_worker
 - licensify


### PR DESCRIPTION
Bouncer has been migrated to EKS.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
