### PR TITLE
Environment ordering

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -20,13 +20,14 @@ class Application < ApplicationRecord
 
   default_scope { order("name ASC") }
 
-  def latest_deploy_to_each_environment
-    return @latest_deploy_to_each_environment unless @latest_deploy_to_each_environment.nil?
+  ENVIRONMENTS_ORDER = %w[integration staging production].freeze
 
-    environments = deployments.select("DISTINCT environment").map(&:environment)
-    @latest_deploy_to_each_environment = environments.index_with do |environment|
+  def latest_deploy_to_each_environment
+    envs = deployed_to_ec2? ? ENVIRONMENTS_ORDER : ENVIRONMENTS_ORDER.map { |env| "#{env} EKS" }
+    @latest_deploy_to_each_environment ||= envs.index_with do |environment|
       deployments.last_deploy_to(environment)
     end
+    @latest_deploy_to_each_environment.compact
   end
 
   def latest_deploy_to(*environments)

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -7,6 +7,7 @@ class DeploymentsControllerTest < ActionController::TestCase
 
   context "GET recent" do
     setup do
+      Deployment.delete_all
       @application = FactoryBot.create(:application, name: "Foo")
       @deployments = FactoryBot.create_list(:deployment, 10, application_id: @application.id)
     end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -301,4 +301,59 @@ class ApplicationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#latest_deploy_to_each_environment" do
+    should "orders main environments" do
+      Deployment.delete_all
+      Application.delete_all
+
+      app = FactoryBot.create(:application)
+
+      production = FactoryBot.create(:deployment, application: app, environment: "production EKS")
+      staging = FactoryBot.create(:deployment, application: app, environment: "staging EKS")
+      integration = FactoryBot.create(:deployment, application: app, environment: "integration EKS")
+
+      expected = {
+        "integration EKS" => integration,
+        "staging EKS" => staging,
+        "production EKS" => production,
+      }
+
+      assert_equal(expected.keys, app.latest_deploy_to_each_environment.keys)
+    end
+
+    should "ignores non-main environments" do
+      Deployment.delete_all
+      Application.delete_all
+
+      app = FactoryBot.create(:application)
+
+      FactoryBot.create(:deployment, application: app, environment: "training")
+      FactoryBot.create(:deployment, application: app, environment: "preview")
+      production = FactoryBot.create(:deployment, application: app, environment: "production EKS")
+      staging = FactoryBot.create(:deployment, application: app, environment: "staging EKS")
+      integration = FactoryBot.create(:deployment, application: app, environment: "integration EKS")
+
+      expected = {
+        "integration EKS" => integration,
+        "staging EKS" => staging,
+        "production EKS" => production,
+      }
+
+      assert_equal(expected.keys, app.latest_deploy_to_each_environment.keys)
+    end
+
+    should "handle applications with only one environment" do
+      Deployment.delete_all
+      Application.delete_all
+
+      app = FactoryBot.create(:application)
+
+      production = FactoryBot.create(:deployment, application: app, environment: "production EKS")
+
+      expected = { "production EKS" => production }
+
+      assert_equal(expected.keys, app.latest_deploy_to_each_environment.keys)
+    end
+  end
 end


### PR DESCRIPTION
On Release, after this change, the environment table follows
a logical order of integration -> staging -> production.

Any non-main environments (ie.: Training, Preview, etc.) will be listed following those
at the bottom, as per the survey result posted in [#govuk-developers](https://gds.slack.com/archives/CAB4Q3QBW/p1684748094130869).

![envorder](https://github.com/alphagov/release/assets/99875822/a3a12be0-19f1-40dd-8c54-104028147f7f)

Furthermore, after the change, the table will display either the regular main environments, or the new EKS environments, depending on where the application is deployed.

https://trello.com/c/6nA6tcOX/3169-fix-order-of-environments-in-release-app