### PR TITLE
Fix application status

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -45,7 +45,7 @@ class Application < ApplicationRecord
     envs = %w[production staging integration]
     envs = envs.map { |env| "#{env} EKS" } unless deployed_to_ec2?
 
-    return :production_and_staging_not_in_sync unless in_sync?(envs[0, 1])
+    return :production_and_staging_not_in_sync unless in_sync?(envs.take(2))
     return :undeployed_changes_in_integration unless in_sync?(envs)
 
     :all_environments_match


### PR DESCRIPTION
## What

“Production and staging not in sync” status was incorrectly reported as “Undeployed changes in integration”.

This was because `envs[0, 1]` returns only the first element of the array that is `["production"]` or `["production EKS"]`.  The #in_sync? methods is checking if the number of unique versions (length of the array) is less or equal to 1 for given environments. Therefore it could on only ever return true for an array with one element.

The full array was then compared and since there were version differences, the status method was returning :undeployed_changes_in_integration

This updates the status method to use #take method which returns first n elements from the array.  
It also adds the tests.

## How to test
- visit /applications path

### Before
<img width="664" alt="Screenshot 2023-05-24 at 11 43 14" src="https://github.com/alphagov/release/assets/38078064/f5be0dd7-efc8-4dd1-8455-f86853e5bdd3">
<img width="678" alt="Screenshot 2023-05-23 at 14 44 13" src="https://github.com/alphagov/release/assets/38078064/e2da2da3-08a6-4fb2-8bac-9a9e1e3e9345">


### After
<img width="745" alt="Screenshot 2023-05-23 at 22 05 46" src="https://github.com/alphagov/release/assets/38078064/c31ab211-991b-4f2e-98f9-df9f7d38011f">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
