### PR TITLE
Don't show Release tag column for apps deployed to EKS

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -22,7 +22,9 @@
     <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Commit log", { caption_classes: "govuk-visually-hidden" }) do |t| %>
       <%= t.head do %>
         <%= t.header "Deployed to" %>
-        <%= t.header "Release tags" %>
+        <% if @application.deployed_to_ec2? %>
+          <%= t.header "Release tags" %>
+        <% end %>
         <%= t.header "Commit" %>
         <%= t.header "Commit SHA" %>
       <% end %>
@@ -43,14 +45,16 @@
             <% end %>
 
             <%= t.cell commit_deployments || "" %>
-
-            <% commit_tags = capture do %>
-              <% tags.each do |tag| %>
-                <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
+            
+            <% if @application.deployed_to_ec2? %>
+              <% commit_tags = capture do %>
+                <% tags.each do |tag| %>
+                  <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
+                <% end %>
               <% end %>
-            <% end %>
 
-            <%= t.cell commit_tags || "" %>
+              <%= t.cell commit_tags || "" %>
+            <% end %>
 
             <% commit_message = capture do %>
               <p class="govuk-body-s govuk-!-margin-bottom-0">

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -4,6 +4,7 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
   setup do
     @app1 = FactoryBot.create(:application)
     @app2 = FactoryBot.create(:application)
+    Application.any_instance.stubs(:deployed_to_ec2?).returns(true)
     login_as_stub_user
     stub_deploy_and_release_page_api_requests_for(@app1, "release_1000")
     stub_deploy_and_release_page_api_requests_for(@app2, "release_200")


### PR DESCRIPTION
Apps deployed to EKS don't have release tags and the column is empty. 
Removing the column will improve readability.

### App deployed to AWS (EC2)
<kbd>
<img width="795" alt="Screenshot 2023-06-13 at 08 50 03" src="https://github.com/alphagov/release/assets/38078064/5778171a-63e5-4627-97cc-15aef1493c31">
</kbd>

### App deployed to EKS
<kbd><img width="802" alt="Screenshot 2023-06-13 at 08 57 13" src="https://github.com/alphagov/release/assets/38078064/57eeee82-7f3b-42b0-a174-44d8d5f10724">
</kbd>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
