### PR TITLE
Correct release app url in the Deploy badger message

### DIFF
--- a/app/services/post_out_of_sync_deploys_service.rb
+++ b/app/services/post_out_of_sync_deploys_service.rb
@@ -28,6 +28,6 @@ private
   end
 
   def app_info(app)
-    "- <#{Plek.find('release')}/applications/#{app[:shortname]}|#{app[:name]}> – #{app[:status].to_s.humanize} (<https://github.com/#{app[:repo]}/actions/workflows/deploy.yml|Deploy GitHub action>)"
+    "- <#{Plek.external_url_for('release')}/applications/#{app[:shortname]}|#{app[:name]}> – #{app[:status].to_s.humanize} (<https://github.com/#{app[:repo]}/actions/workflows/deploy.yml|Deploy GitHub action>)"
   end
 end


### PR DESCRIPTION
It needs to return `https` rather than `http`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
