### PR TITLE
Explain 'Deployment freeze' process for EKS apps

### DIFF
--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -63,6 +63,24 @@
       }
     ]
   } %>
+  
+  <% hint_text = capture do %>
+    <% if @application.deployed_to_ec2? %>
+      Disables automatic deployments. Our deploy jobs will query the value of this flag in the API and abort if it is set. Manual deploy job builds will continue to work.
+    <% else %>
+      Adds 'Automatic deployments disabled' badge in the Release app.
+      
+      <% unless current_page?(action: 'new') %>
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+              Continious deployment between each environment has to be disabled or enabled via <%= link_to "GitHub action", "https://github.com/#{@application.repo}/actions/workflows/set-automatic-deploys.yml", class: "govuk-link" %>.
+          </strong>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
 
   <input type="hidden" name="application[deploy_freeze]" value="0" />
   <%= render "govuk_publishing_components/components/checkboxes", {
@@ -72,7 +90,7 @@
         label: "Freeze deployments?",
         value: "1",
         checked: @application.deploy_freeze?,
-        hint: "Disables automatic deployments. Our deploy jobs will query the value of this flag in the API and abort if it is set. Manual deploy job builds will continue to work."
+        hint: hint_text,
       }
     ]
   } %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -252,6 +252,11 @@ class ApplicationsControllerTest < ActionController::TestCase
       get :edit, params: { id: @app.id }
       assert_select "form.edit_application input[name='application[shortname]'][value='#{@app.shortname}']"
     end
+
+    should "show warning that an EKS deployed app has have deployments disabled via GitHub action" do
+      get :edit, params: { id: @app.id }
+      assert_select ".govuk-warning-text__text", /Continious deployment between each environment has to be disabled or enabled * via GitHub action/
+    end
   end
 
   context "PUT update" do


### PR DESCRIPTION
## What

Adds explanation of the  'Deployment freeze' process for EKS apps.
Assumed no new EC2 apps will be created.

| Before | 
| --- | 
| <img width="763" alt="Screenshot 2023-06-14 at 21 52 50" src="https://github.com/alphagov/release/assets/38078064/da0aca0c-5777-425a-9419-7c6e03cc3522"> |

| After - Edit page | 
| --- | 
| <img width="663" alt="Screenshot 2023-06-14 at 21 52 36" src="https://github.com/alphagov/release/assets/38078064/f09026a4-41e4-46c1-89f5-97195ab93e68"> |

| After - Create new | 
| --- | 
| <img width="666" alt="Screenshot 2023-06-14 at 21 45 42" src="https://github.com/alphagov/release/assets/38078064/fba38974-45e9-48fc-8d84-b0bdb751fc0e"> |

## Why

The code freeze feature of the Release app doesn’t work on the new platform. Automatic deploys are now disabled via a config setting in govuk-helm-charts [^1]. This can be switched on or off using "Set automatic deploys" GitHub Action. Disabling automatic deploys for Integration, will disable promotion from Integration to Staging.

[Trello](https://trello.com/c/bS9qvE1q/3212-deprecate-code-freeze-behaviour-in-release-app-1)

We don't include the link on the Create a new application form.

## How to test it
- visit application edit path e.g. https://release.publishing.service.gov.uk/applications/account-api/edit (for EKS and EC2)
- visit new path: `/applications/new`

[^1]: https://github.com/alphagov/govuk-helm-charts/blob/e80278a385835ac3a30866bb11458b9442b6a5ba/charts/app-config/image-tags/integration/collections#L2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
