### PR TITLE
Use apps.json endpoint instead of repos.json

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -3,7 +3,7 @@ class Repo
   base_uri "docs.publishing.service.gov.uk"
 
   def self.all
-    response ||= get("/repos.json")
+    response ||= get("/apps.json")
     JSON.parse(response.body)
   rescue HTTParty::Error, JSON::ParserError => e
     Rails.logger.debug "Error fetching govuk repos: #{e.message}"

--- a/test/unit/find_out_of_sync_deploys_service_test.rb
+++ b/test/unit/find_out_of_sync_deploys_service_test.rb
@@ -14,7 +14,7 @@ class FindOutOfSyncDeploysServiceTest < ActiveSupport::TestCase
         { "app_name" => "authenticating-proxy", "team" => "#govuk-navigation-tech" },
       ].to_json
 
-      stub_request(:get, "http://docs.publishing.service.gov.uk/repos.json").to_return(status: 200, body: response_body)
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
 
       app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
       FactoryBot.create(:deployment, application: app, version: "111", environment: "production EKS")
@@ -79,7 +79,7 @@ class FindOutOfSyncDeploysServiceTest < ActiveSupport::TestCase
 
     should "return general dev slack channel when it can't find team (because app names don't match)" do
       response_body = [{ "app_name" => "content-data-admin", "team" => "#govuk-platform-security-reliability-team" }].to_json
-      stub_request(:get, "http://docs.publishing.service.gov.uk/repos.json").to_return(status: 200, body: response_body)
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
 
       app = FactoryBot.create(:application, name: "Content Data", shortname: "content-data")
       FactoryBot.create(:deployment, application: app, version: "111", environment: "production EKS")

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class RepoTest < ActiveSupport::TestCase
   describe ".all" do
     should "return an array of repositories" do
-      stub_request(:get, "http://docs.publishing.service.gov.uk/repos.json").to_return(
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(
         status: 200,
         body: '[{"name": "repo1"}, {"name": "repo2"}]',
       )
@@ -14,7 +14,7 @@ class RepoTest < ActiveSupport::TestCase
     end
 
     should "handle HTTParty errors gracefully" do
-      stub_request(:get, "http://docs.publishing.service.gov.uk/repos.json").to_return(status: 404)
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 404)
 
       HTTParty.stub(:get, -> { raise HTTParty::Error }) do
         repos = Repo.all


### PR DESCRIPTION
We should only be looking at GOV.UK apps, not all GOV.UK repos. This wasn't an issue before, but we've just made improvements to the Developer Docs such that repos that contain multiple apps are no longer listed multiple times, which would mean we'd lose access to licensify-feed and licensify-admin information.

Using the apps.json endpoint means we have access to all the app information we need, and none of the irrelevant repos' info.

See https://github.com/alphagov/govuk-developer-docs/pull/4058

Trello: https://trello.com/c/tsBL9lPH/3161-work-through-list-of-missing-repos

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
