### PR TITLE
Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,4 +460,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.4.14


### PR DESCRIPTION
Updated with `bundle update --bundler`

Removes warnings:
```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
/root/.rbenv/versions/3.1.2/lib/ruby/3.1.0/set.rb:815: warning: already initialized constant Set::InspectKey
/root/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/set-1.0.3/lib/set.rb:815: warning: previous definition of InspectKey was here
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
