### PR TITLE
Removed reference as application has been retired.

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -2,7 +2,6 @@
 - asset-manager
 - authenticating-proxy
 - bouncer
-- cache-clearing-service
 - collections
 - collections-publisher
 - contacts


### PR DESCRIPTION
Removed cache-clearing-service reference as it has been retired.

https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service

https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings