### PR TITLE
Remove Licence Finder from seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,6 @@ applications = [
   { name: "Feedback",                               repo: "alphagov/feedback" },
   { name: "Frontend",                               repo: "alphagov/frontend", status_notes: example_note },
   { name: "Imminence",                              repo: "alphagov/imminence" },
-  { name: "Licence finder",                         repo: "alphagov/licence-finder", shortname: "licencefinder" },
   { name: "Licensify",                              repo: "alphagov/licensify" },
   { name: "Publisher",                              repo: "alphagov/publisher" },
   { name: "Rummager",                               repo: "alphagov/rummager" },


### PR DESCRIPTION
Small cleanup for: https://trello.com/c/1VXQW5I1/2127-epic-retire-original-licence-finder-application

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

