### PR TITLE
Version releases and images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.tag_name, 'v') 
     name: Build and publish image
+    # TODO: switch this to track main branch
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@add-version-tag
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,16 +19,14 @@ on:
         - staging
         - production
         default: 'integration'
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  release:
+    types: [released]
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.tag_name, 'v') 
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@add-version-tag
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    name: Release
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@add-version-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,5 @@ jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Release
+    # TODO: switch this to track main branch
     uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@add-version-tag


### PR DESCRIPTION
This adds a workflow to automatically create new releases on merges to main. Also modifies deploy action to only automatically deploy when a new release is created.

This PR referencing a branch of govuk-infrastructure to test these new reusable workflows.