### PR TITLE
Fix the deploy and release workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,11 @@ on:
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.tag_name, 'v') 
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v') 
     name: Build and publish image
-    # TODO: switch this to track main branch
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@add-version-tag
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref }}
+      gitRef: ${{ inputs.gitRef || github.ref_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   workflow_dispatch:
   workflow_run:
@@ -14,5 +11,6 @@ jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Release
-    # TODO: switch this to track main branch
-    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@add-version-tag
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This fixes the git ref name passed to reusable deploy workflow. Switches the workflows to reference the reusable workflows from main. Also fixes passing in the GitHub Token, as workflows cannot be trigger on events created with the automatically generated token by GitHub Actions. (Hence the deploy workflow wouldn't be triggered by a release.)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
