### PR TITLE
Revert "Don't show Release tag column for apps deployed to EKS"

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -22,9 +22,7 @@
     <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Commit log", { caption_classes: "govuk-visually-hidden" }) do |t| %>
       <%= t.head do %>
         <%= t.header "Deployed to" %>
-        <% if @application.deployed_to_ec2? %>
-          <%= t.header "Release tags" %>
-        <% end %>
+        <%= t.header "Release tags" %>
         <%= t.header "Commit" %>
         <%= t.header "Commit SHA" %>
       <% end %>
@@ -45,16 +43,14 @@
             <% end %>
 
             <%= t.cell commit_deployments || "" %>
-            
-            <% if @application.deployed_to_ec2? %>
-              <% commit_tags = capture do %>
-                <% tags.each do |tag| %>
-                  <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
-                <% end %>
-              <% end %>
 
-              <%= t.cell commit_tags || "" %>
+            <% commit_tags = capture do %>
+              <% tags.each do |tag| %>
+                <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
+              <% end %>
             <% end %>
+
+            <%= t.cell commit_tags || "" %>
 
             <% commit_message = capture do %>
               <p class="govuk-body-s govuk-!-margin-bottom-0">

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -4,7 +4,6 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
   setup do
     @app1 = FactoryBot.create(:application)
     @app2 = FactoryBot.create(:application)
-    Application.any_instance.stubs(:deployed_to_ec2?).returns(true)
     login_as_stub_user
     stub_deploy_and_release_page_api_requests_for(@app1, "release_1000")
     stub_deploy_and_release_page_api_requests_for(@app2, "release_200")


### PR DESCRIPTION
Deployments for apps to EKS are now getting release tags.

e.g. https://github.com/alphagov/whitehall/pull/8082