### PR TITLE
Refactor settings page

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,7 +3,7 @@ class SitesController < ApplicationController
 
   def update
     if site_settings.update(site_params)
-      redirect_to root_path, notice: "Site settings updated"
+      redirect_to root_path, notice: "Settings updated"
     else
       render :show, status: :unprocessable_entity
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
     items << { text: "Applications", href: applications_path, active: is_current?(applications_path) }
     items << { text: "Deploys", href: activity_path, active: is_current?(activity_path) }
     items << { text: "Archived", href: archived_applications_path, active: is_current?(archived_applications_path) }
-    items << { text: "Site settings", href: site_path, active: is_current?(site_path) }
+    items << { text: "Settings", href: site_path, active: is_current?(site_path) }
     items << { text: "Stats", href: stats_path, active: is_current?(stats_path) }
 
     items << { text: current_user.name, href: Plek.new.external_url_for("signon") }

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,13 +1,5 @@
 <% content_for :page_title, 'Settings' %>
 
-<%= render "govuk_publishing_components/components/breadcrumbs", {
-  breadcrumbs: [
-    {
-      title: "Settings"
-    }
-  ]
-} %>
-
 <%= render "shared/form_errors", resource: site_settings %>
 
 <%= render "govuk_publishing_components/components/title", {

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -6,13 +6,17 @@
   title: "Settings"
 } %>
 
+
 <%= form_for site_settings, url: site_path, method: 'patch' do |f| %>
   <%= render "govuk_publishing_components/components/character_count", {
     textarea: {
       label: {
-        text: "Notes"
+        is_page_heading: true,
+        heading_size: "l",
+        text: "Global status note"
       },
       name: "site[status_notes]",
+      hint: "Display a note on all application pages",
       value: site_settings.status_notes,
       error_message: site_settings.errors[:status_notes].first,
     },
@@ -20,8 +24,8 @@
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Save status notes",
-    value: "Save status notes",
+    text: "Save",
+    value: "Save",
     name: "commit"
   } %>
 <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,9 +1,9 @@
-<% content_for :page_title, 'Site settings' %>
+<% content_for :page_title, 'Settings' %>
 
 <%= render "govuk_publishing_components/components/breadcrumbs", {
   breadcrumbs: [
     {
-      title: "Site settings"
+      title: "Settings"
     }
   ]
 } %>
@@ -11,7 +11,7 @@
 <%= render "shared/form_errors", resource: site_settings %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: "Site settings"
+  title: "Settings"
 } %>
 
 <%= form_for site_settings, url: site_path, method: 'patch' do |f| %>

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -16,11 +16,11 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
     assert page.has_no_selector?(".gem-c-notice")
     assert page.has_no_selector?(".gem-c-error-alert")
 
-    click_on "Site settings"
+    click_on "Settings"
 
     fill_in "Notes", with: "Christmas deploy freeze in place. Emergency deploys only until 2nd Jan"
     click_on "Save status notes"
-    assert page.has_selector?(".gem-c-success-alert", text: "Site settings updated")
+    assert page.has_selector?(".gem-c-success-alert", text: "Settings updated")
     assert_equal "/applications", current_path
 
     visit "/"
@@ -36,10 +36,10 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
     click_on "release_200"
     assert page.has_selector?(".gem-c-error-alert", text: "Christmas deploy freeze in place. Emergency deploys only until 2nd Jan"), "Global status note is missing from Application 2 release_200 tag deploy page"
 
-    click_on "Site settings"
+    click_on "Settings"
     fill_in "Notes", with: ""
     click_on "Save status notes"
-    assert page.has_selector?(".gem-c-success-alert", text: "Site settings updated")
+    assert page.has_selector?(".gem-c-success-alert", text: "Settings updated")
     assert_equal "/applications", current_path
 
     visit "/"

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -18,8 +18,8 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
 
     click_on "Settings"
 
-    fill_in "Notes", with: "Christmas deploy freeze in place. Emergency deploys only until 2nd Jan"
-    click_on "Save status notes"
+    fill_in "Global status note", with: "Christmas deploy freeze in place. Emergency deploys only until 2nd Jan"
+    click_on "Save"
     assert page.has_selector?(".gem-c-success-alert", text: "Settings updated")
     assert_equal "/applications", current_path
 
@@ -37,8 +37,8 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
     assert page.has_selector?(".gem-c-error-alert", text: "Christmas deploy freeze in place. Emergency deploys only until 2nd Jan"), "Global status note is missing from Application 2 release_200 tag deploy page"
 
     click_on "Settings"
-    fill_in "Notes", with: ""
-    click_on "Save status notes"
+    fill_in "Global status note", with: ""
+    click_on "Save"
     assert page.has_selector?(".gem-c-success-alert", text: "Settings updated")
     assert_equal "/applications", current_path
 


### PR DESCRIPTION
This PR does the following:

- This renames the setting page to "Settings" as is more concise and "site" doesn't give the page more context about its functionality.
- Removes the breadcrumb that just takes up space and isn't functional (as there's no forward navigation from this page)
- Updates the heading and hint for the global status note field, had no idea what this setting did beforehand.

After:
![image](https://github.com/alphagov/release/assets/11051676/98949ca6-641d-42e1-91b7-681b104eca33)

Before:
![image](https://github.com/alphagov/release/assets/11051676/d7295a98-d311-480f-bc32-92e2b9a9e5b7)
