### PR TITLE
Mark govuk-dependency-checker as continuously deployed

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -16,6 +16,7 @@
 - feedback
 - finder-frontend
 - frontend
+- govuk-dependency-checker
 - government-frontend
 - govuk-account-manager-prototype
 - govuk-attribute-service-prototype


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-helm-charts/pull/1247

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
