### PR TITLE
Include non default branch deploys in commit log

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -90,6 +90,10 @@ class Application < ApplicationRecord
     Services.github.commits(repo)
   end
 
+  def latest_commit(application, commit_sha)
+    Services.github.commit(application.repo, commit_sha)
+  end
+
   def tag_names_by_commit
     tags = Services.github.tags(repo)
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -28,12 +28,14 @@
       <% end %>
 
       <%= t.body do %>
+        <% latest_deploy_on_default_branch = [] %>
         <% @commits.each do |commit| %>
           <%= t.row do %>
             <% tags = @tag_names_by_commit.fetch(commit[:sha], []) %>
             <% commit_deployments = capture do %>
-              <% @application.latest_deploy_to_each_environment.each do |_, deployment| %>
+              <% @application.latest_deploy_to_each_environment.each do |environment, deployment| %>
                 <% if tags.include?(deployment.version) || deployment.commit_match?(commit[:sha]) %>
+                  <% latest_deploy_on_default_branch << environment %>
                   <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
                     <span class="release__commits-label release__commits-label--<%= 'production' if deployment.to_live_environment? %>"><%= deployment.environment.humanize %></span>
                     <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
@@ -65,6 +67,36 @@
 
             <%= t.cell commit_message %>
             <%= t.cell link_to(commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank", class: "release__commit-hash govuk-link govuk-body-s") %>
+          <% end %>
+        <% end %>
+        <% @application.latest_deploy_to_each_environment.each do |environment, deployment| %>
+          <% if !latest_deploy_on_default_branch.include?(environment) %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
+                  <span class="release__commits-label release__commits-label--<%= 'production' if deployment.to_live_environment? %>"><%= environment.humanize %></span>
+                    <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
+                </p>
+                <span class="release__badge release__badge--orange">Not on default branch</span>
+              </td>
+              <td class="govuk-table__cell"/>
+              <td class="govuk-table__cell">
+                <p class="govuk-body-s govuk-!-margin-bottom-0">
+                  <% latest_deployed_commit = @application.latest_commit(@application, deployment.version) %>
+                  <%= latest_deployed_commit[:commit][:message] %>
+                  <% if latest_deployed_commit[:commit][:author] %>
+                    <span class="release__commits-author">
+                      <%= latest_deployed_commit[:commit][:author][:name] %>
+                    </span>
+                  <% end %>
+                </p>
+              </td>
+              <td class="govuk-table__cell">
+                <p class="govuk-body-s govuk-!-margin-bottom-1">
+                  <%= link_to(deployment.version[0..8], "#{@application.repo_url}/commit/#{deployment.version}", target: "_blank", class: "release__commit-hash govuk-link govuk-body-s") %>
+                </p>
+              </td>
+            </tr>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
The commit log on an application summary page only lists commits for the default branch (main) and does not include manual deploys from other branches.

Whilst this is included in the "What's where" section at the bottom of the page, it's helpful to also include them in the commit log section where it is easier to see if an environment is currently out of sync with `main`.

If any environments have not yet been rendered to the table with its latest deployed commit, we get the last deployed commit for those environments and add them as final entries to the commit log table.

### Before
<img width="1256" alt="Screenshot 2023-08-17 at 16 59 42" src="https://github.com/alphagov/release/assets/19667619/b74babcd-2cec-4dff-93f4-3ca4de12c23b">

### After
<img width="1244" alt="Screenshot 2023-08-17 at 17 00 03" src="https://github.com/alphagov/release/assets/19667619/3cf764ff-c20b-4b95-a81c-db125509dfe6">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
