### PR TITLE
Filter Recent Deployments by Environments

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -15,7 +15,10 @@ class DeploymentsController < ApplicationController
   end
 
   def recent
-    @deployments = Deployment.includes(:application).newest_first.limit(25)
+    env = recent_deployment_params[:environment_filter]
+
+    filtered_deployments = env ? Deployment.where(environment: [env, "#{env} EKS"]) : Deployment
+    @deployments = filtered_deployments.includes(:application).newest_first.limit(25)
   end
 
   def new
@@ -129,6 +132,12 @@ private
     params.permit(
       :application_id,
       :environment,
+    )
+  end
+
+  def recent_deployment_params
+    params.permit(
+      :environment_filter,
     )
   end
 end

--- a/app/views/deployments/recent.html.erb
+++ b/app/views/deployments/recent.html.erb
@@ -13,5 +13,27 @@
   title: "Recent deployments"
 } %>
 
+<%= form_tag(activity_path, method: :get) do %>
+  <div class="govuk-form-group">
+    <%= render "govuk_publishing_components/components/label", {
+      text: "Filter environment",
+      html_for: "deployment-environment-filter",
+      bold: true
+    } %>
+
+    <%= select_tag "environment_filter",
+      options_for_select(Application::ENVIRONMENTS_ORDER.map(&:capitalize), [params[:environment_filter]]),
+      include_blank: true,
+      id: "deployment-environment-filter",
+      class: "govuk-select"
+    %>
+  </div>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Filter",
+    margin_bottom: true
+  } %>
+<% end %>
+
   <%= render "deployments_list", deploys: @deployments %>
 </section>

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -24,6 +24,15 @@ class DeploymentsControllerTest < ActionController::TestCase
 
       assert_equal 10, assigns(:deployments).size
     end
+
+    should "assign only filtered environments" do
+      FactoryBot.create(:deployment, application_id: @application.id, environment: "integration EKS")
+      FactoryBot.create(:deployment, application_id: @application.id, environment: "integration")
+
+      get :recent, params: { environment_filter: "Integration" }
+
+      assert_equal 2, assigns(:deployments).size
+    end
   end
 
   context "GET new" do


### PR DESCRIPTION
This could be useful for things like finding out which deploys have happened on production recently, to aid in debugging a live incident.

It would also allow going further back in history, as currently the search is restricted to the last 25 deployments across all envs, so being able to show 25 deployments in a single env will show more results that would otherwise be lost.

https://trello.com/c/aibwammr/3213-filter-by-environment-in-release-app-recent-deployments-page-3

<img width="1147" alt="Release Environment Filter" src="https://github.com/alphagov/release/assets/99875822/553eac04-d2c3-43a6-8dd0-c01d304e208f">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

