### PR TITLE
Fix release SHA in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
     <%= yield %>
   </main>
 
-  <p class="govuk-body-s">Version: <%= CURRENT_RELEASE_SHA %></p>
+  <% if !CURRENT_RELEASE_SHA.nil? %>
+    <p class="govuk-body-s">Version: <%= CURRENT_RELEASE_SHA %></p>
+  <% end %>
 </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {} %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,6 +1,1 @@
-if Rails.root.join("REVISION").exist?
-  revision = File.read(Rails.root.join("REVISION")).chomp
-  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
-else
-  CURRENT_RELEASE_SHA = "development".freeze
-end
+CURRENT_RELEASE_SHA = `git rev-parse HEAD`.chomp[0..10] # Just get the short SHA


### PR DESCRIPTION
This has been broken since we moved to EKS and the SHA is no longer provided.

Before:

<img width="1258" alt="Screenshot 2023-09-14 at 17 00 36" src="https://github.com/alphagov/release/assets/19667619/651046e2-5561-406f-b140-0c8df2d9da29">

After:

<img width="1235" alt="Screenshot 2023-09-14 at 16 57 43" src="https://github.com/alphagov/release/assets/19667619/78fbc362-a588-4c5d-a986-71fd52a000e3">

Trello card: https://trello.com/c/uoKDUcbV/3182-fix-broken-version-footer-in-publishing-apps-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
