### PR TITLE
Revert fix for version in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,9 +27,7 @@
     <%= yield %>
   </main>
 
-  <% if !CURRENT_RELEASE_SHA.nil? %>
-    <p class="govuk-body-s">Version: <%= CURRENT_RELEASE_SHA %></p>
-  <% end %>
+  <p class="govuk-body-s">Version: <%= CURRENT_RELEASE_SHA %></p>
 </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {} %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,1 +1,6 @@
-CURRENT_RELEASE_SHA = `git rev-parse HEAD`.chomp[0..10] # Just get the short SHA
+if Rails.root.join("REVISION").exist?
+  revision = File.read(Rails.root.join("REVISION")).chomp
+  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
+else
+  CURRENT_RELEASE_SHA = "development".freeze
+end


### PR DESCRIPTION
Reverts https://github.com/alphagov/release/pull/1287/commits/887a079765233a7d68da84aeff8877d6e3320e5a

The deployment to Integration fails with
`Errno::ENOENT: No such file or directory - git`

Related PR: https://github.com/alphagov/release/pull/1287

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
