### PR TITLE
Fix release version in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
     <%= yield %>
   </main>
 
-  <p class="govuk-body-s">Version: <%= CURRENT_RELEASE_SHA %></p>
+  <% if !CURRENT_RELEASE_TAG.nil? %>
+    <p class="govuk-body-s">Version: <%= CURRENT_RELEASE_TAG %></p>
+  <% end %>
 </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {} %>

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,6 +1,1 @@
-if Rails.root.join("REVISION").exist?
-  revision = File.read(Rails.root.join("REVISION")).chomp
-  CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
-else
-  CURRENT_RELEASE_SHA = "development".freeze
-end
+CURRENT_RELEASE_TAG = ENV["SENTRY_RELEASE"]


### PR DESCRIPTION
This has been broken since we moved to EKS and the SHA is no longer provided.

We can use the [SENTRY_RELEASE](https://github.com/alphagov/govuk-helm-charts/blob/077117e7f40c096a958f9e0b853a2bd76cf43f26/charts/generic-govuk-app/templates/deployment.yaml#L92C1-L92C1) environment variable which is defined for every app and takes its value from the container image's tag.

Before:
<img width="1258" alt="Screenshot 2023-09-14 at 17 00 36" src="https://github.com/alphagov/release/assets/19667619/87539fc0-4765-4d0f-a36c-4a5cd2c98d38">

After (tested in Integration):
<img width="975" alt="Screenshot 2023-09-20 at 11 46 57" src="https://github.com/alphagov/release/assets/19667619/87c219a2-f414-47b0-8310-3ae452f7194f">

Trello card: https://trello.com/c/uoKDUcbV/3182-fix-broken-version-footer-in-publishing-apps-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
