### PR TITLE
Create .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,0 +1,26 @@
+api_version: 1
+auto_merge:
+  - dependency: gds-sso
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_app_config
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_publishing_components
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: govuk_sidekiq
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: plek
+    allowed_semver_bumps:
+      - patch
+      - minor
+  - dependency: rubocop-govuk
+    allowed_semver_bumps:
+      - patch
+      - minor


### PR DESCRIPTION
Allow internal GDS dependencies to be auto-merged.

https://trello.com/c/tUU1YoaS/3387-enable-auto-merging-on-remaining-psr-repos

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
