### PR TITLE
Migrate from Sidekiq workers to ActiveJob (with Sidekiq as the backend)

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/slack_poster_job.rb
+++ b/app/jobs/slack_poster_job.rb
@@ -1,8 +1,8 @@
 require "httparty"
 
-class SlackPosterWorker
-  include Sidekiq::Worker
-  sidekiq_options retry: 1
+class SlackPosterJob < ApplicationJob
+  queue_as :default
+  retry_on Exception, attempts: 2
 
   VALID_OPTIONS = %w[username icon_emoji mrkdown].freeze
 

--- a/app/services/post_out_of_sync_deploys_service.rb
+++ b/app/services/post_out_of_sync_deploys_service.rb
@@ -9,7 +9,7 @@ class PostOutOfSyncDeploysService
     return if teams_out_of_sync_deploys.empty?
 
     teams_out_of_sync_deploys.each do |team_channel, apps|
-      SlackPosterWorker.perform_async(
+      SlackPosterJob.perform_later(
         formatted_slack_message(apps),
         team_channel,
         { "icon_emoji" => ":badger:" },

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,7 @@ module ReleaseApp
     # Set asset path to be application specific so that we can put all GOV.UK
     # assets into an S3 bucket and distinguish app by path.
     config.assets.prefix = "/assets/release"
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,6 @@ class ActiveSupport::TestCase
 
   teardown do
     DatabaseCleaner.clean
-    Sidekiq::Worker.clear_all
   end
 end
 

--- a/test/unit/jobs/slack_poster_job_test.rb
+++ b/test/unit/jobs/slack_poster_job_test.rb
@@ -1,48 +1,46 @@
 require "test_helper"
 
 class SlackPosterJobTest < ActiveJob::TestCase
-  context "#perform" do
-    setup do
-      @webhook_url = "https://hooks.slack.com/services/T000/B00/XXX"
-    end
+  setup do
+    @webhook_url = "https://hooks.slack.com/services/T000/B00/XXX"
+  end
 
-    should "enqueue a job" do
-      assert_enqueued_with job: SlackPosterJob do
-        mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
-          SlackPosterJob.perform_later("Hello", "#testchannel")
-        end
-      end
-    end
-
-    should "send a post request" do
+  should "enqueue a job" do
+    assert_enqueued_with job: SlackPosterJob do
       mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
-        stub_post = stub_request(:post, @webhook_url).with(
-          body: "{\"username\":\"Release app\",\"icon_emoji\":\":govuk:\",\"mrkdwn\":\"true\",\"text\":\"Hello\",\"channel\":\"#testchannel\"}",
-        ).to_return(status: 200, body: "ok", headers: {})
-
-        SlackPosterJob.perform_now("Hello", "#testchannel")
-
-        assert_requested(stub_post)
+        SlackPosterJob.perform_later("Hello", "#testchannel")
       end
     end
+  end
 
-    should "send a post request when called with vaild options" do
-      mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
-        stub_post = stub_request(:post, @webhook_url).with(
-          body: "{\"username\":\"Release app\",\"icon_emoji\":\":badger:\",\"mrkdwn\":\"true\",\"text\":\"Hello\",\"channel\":\"#testchannel\"}",
-        ).to_return(status: 200, body: "ok", headers: {})
+  should "send a post request" do
+    mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
+      stub_post = stub_request(:post, @webhook_url).with(
+        body: "{\"username\":\"Release app\",\"icon_emoji\":\":govuk:\",\"mrkdwn\":\"true\",\"text\":\"Hello\",\"channel\":\"#testchannel\"}",
+      ).to_return(status: 200, body: "ok", headers: {})
 
-        SlackPosterJob.perform_now("Hello", "#testchannel", { "icon_emoji" => ":badger:" })
+      SlackPosterJob.perform_now("Hello", "#testchannel")
 
-        assert_requested(stub_post)
-      end
+      assert_requested(stub_post)
     end
+  end
 
-    should "not accept invalid options" do
-      perform_enqueued_jobs do
-        assert_raises(StandardError, 'Invalid options, only "username", "icon_emoji", "mrkdown" are permitted') do
-          SlackPosterJob.perform_later("Hello", "#testchannel", { "name" => "Slack poster", "icon_emoji" => ":badger:" })
-        end
+  should "send a post request when called with vaild options" do
+    mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
+      stub_post = stub_request(:post, @webhook_url).with(
+        body: "{\"username\":\"Release app\",\"icon_emoji\":\":badger:\",\"mrkdwn\":\"true\",\"text\":\"Hello\",\"channel\":\"#testchannel\"}",
+      ).to_return(status: 200, body: "ok", headers: {})
+
+      SlackPosterJob.perform_now("Hello", "#testchannel", { "icon_emoji" => ":badger:" })
+
+      assert_requested(stub_post)
+    end
+  end
+
+  should "not accept invalid options" do
+    perform_enqueued_jobs do
+      assert_raises(StandardError, 'Invalid options, only "username", "icon_emoji", "mrkdown" are permitted') do
+        SlackPosterJob.perform_later("Hello", "#testchannel", { "name" => "Slack poster", "icon_emoji" => ":badger:" })
       end
     end
   end

--- a/test/unit/jobs/slack_poster_job_test.rb
+++ b/test/unit/jobs/slack_poster_job_test.rb
@@ -5,14 +5,6 @@ class SlackPosterJobTest < ActiveJob::TestCase
     @webhook_url = "https://hooks.slack.com/services/T000/B00/XXX"
   end
 
-  should "enqueue a job" do
-    assert_enqueued_with job: SlackPosterJob do
-      mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
-        SlackPosterJob.perform_later("Hello", "#testchannel")
-      end
-    end
-  end
-
   should "send a post request" do
     mock_env({ "SLACK_WEBHOOK_URL" => @webhook_url }) do
       stub_post = stub_request(:post, @webhook_url).with(

--- a/test/unit/post_out_of_sync_deploys_service_test.rb
+++ b/test/unit/post_out_of_sync_deploys_service_test.rb
@@ -26,14 +26,14 @@ class PostOutOfSyncDeploysServiceTest < ActiveSupport::TestCase
       slack_poster_mock.expect(:call, nil, expected_args)
 
       FindOutOfSyncDeploysService.stub(:call, find_service_mock) do
-        SlackPosterWorker.stub(:perform_async, slack_poster_mock) do
+        SlackPosterJob.stub(:perform_later, slack_poster_mock) do
           PostOutOfSyncDeploysService.call
           assert_mock find_service_mock
         end
       end
     end
 
-    should "call SlackPosterWorker to post messages with correct payload for each team with out-of-sync deploys" do
+    should "call SlackPosterJob to post messages with correct payload for each team with out-of-sync deploys" do
       teams_out_of_sync_deploys = {
         "#govuk-publishing-platform" =>
           [{ name: "Asset manager",
@@ -75,17 +75,17 @@ class PostOutOfSyncDeploysServiceTest < ActiveSupport::TestCase
       slack_poster_mock.expect(:call, nil, expected_message_one_args)
       slack_poster_mock.expect(:call, nil, expected_message_two_args)
 
-      SlackPosterWorker.stub(:perform_async, slack_poster_mock) do
+      SlackPosterJob.stub(:perform_later, slack_poster_mock) do
         PostOutOfSyncDeploysService.call
         assert_mock slack_poster_mock
       end
     end
 
-    should "not call the SlackPosterWorker when no teams have out-of-sync deploys" do
+    should "not call the SlackPosterJob when no teams have out-of-sync deploys" do
       FindOutOfSyncDeploysService.any_instance.stubs(:call).returns({})
 
       PostOutOfSyncDeploysService.call
-      SlackPosterWorker.any_instance.expects(:perform_async).never
+      SlackPosterJob.expects(:perform_later).never
     end
   end
 end


### PR DESCRIPTION
This doesn't have any user-visible changes, but moving to ActiveJob paves the way for potentially switching out Sidekiq for an alternative queue backend in the future (and it's conceptually cleaner to use a built-in Rails API over a third-party gem).

The newly introduced job has been tested in integration via `SlackPosterJob.perform_now`, but it's not possible to test background job processing in integration or staging because Release doesn't have a worker container in those environments. If this were a public-facing app I would update our Helm charts so I could run a proper test, but in this case the only thing that risks breaking is the Slack integration - I will monitor this after deployment and roll it back if this stops working in production.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️