### PR TITLE
Update the cache format version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,8 @@ module ReleaseApp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     # config.autoload_lib(ignore: %w[assets tasks])
 
+    config.active_support.cache_format_version = 7.0
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
This will silence the deprecation notice for using version 6.1. Version 7 is able to read version 6. More info:
  https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
