### PR TITLE
Mark all apps deployed into EKS and remove EC2 deployment UI elements

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -59,10 +59,6 @@ class Application < ApplicationRecord
     "https://github.com/#{repo}/compare/#{from}...#{to}"
   end
 
-  def self.ec2_deployed_apps
-    @ec2_deployed_apps ||= YAML.safe_load_file("data/ec2_deployed_apps.yml")
-  end
-
   def self.cd_statuses
     @cd_statuses ||= YAML.safe_load(open("data/continuously_deployed_apps.yml"))
   end
@@ -79,8 +75,7 @@ class Application < ApplicationRecord
   end
 
   def deployed_to_ec2?
-    key = shortname || fallback_shortname
-    Application.ec2_deployed_apps.include? key
+    false
   end
 
   def dependency_pull_requests

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -65,20 +65,16 @@
   } %>
   
   <% hint_text = capture do %>
-    <% if @application.deployed_to_ec2? %>
-      Disables automatic deployments. Our deploy jobs will query the value of this flag in the API and abort if it is set. Manual deploy job builds will continue to work.
-    <% else %>
-      Adds 'Automatic deployments disabled' badge in the Release app.
-      
-      <% unless current_page?(action: 'new') %>
-        <div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
-              Continuous deployment between each environment has to be disabled or enabled via <%= link_to "GitHub action", "https://github.com/#{@application.repo}/actions/workflows/set-automatic-deploys.yml", class: "govuk-link" %>.
-          </strong>
-        </div>
-      <% end %>
+    Adds 'Automatic deployments disabled' badge in the Release app.
+    
+    <% unless current_page?(action: 'new') %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+            Continuous deployment between each environment has to be disabled or enabled via <%= link_to "GitHub action", "https://github.com/#{@application.repo}/actions/workflows/set-automatic-deploys.yml", class: "govuk-link" %>.
+        </strong>
+      </div>
     <% end %>
   <% end %>
 

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -21,16 +21,12 @@
 
 <%= render 'status_notes', application: @application %>
 
-<% if @application.deployed_to_ec2? %>
-  <%= render partial: "ec2_deployment_steps", locals: { application: @application, release_tag: @release_tag } %>
-<% else %>
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Deploy this release",
-      href: "https://github.com/#{@application.repo}/actions/workflows/deploy.yml",
-      target: "_blank",
-      margin_bottom: true
-    } %>
-<% end %>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Deploy this release",
+  href: "https://github.com/#{@application.repo}/actions/workflows/deploy.yml",
+  target: "_blank",
+  margin_bottom: true
+} %>
 
 <% if @production_deploy %>
   <p class="govuk-body">Production is on <%= @production_deploy.version %> &mdash; deployed at <%= human_datetime(@production_deploy.created_at) %></p>

--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -5,7 +5,3 @@
 <% unless application.cd_enabled? %>
   <span class="release__badge release__badge--orange">Manually deployed</span>
 <% end %>
-
-<% if application.deployed_to_ec2? %>
-  <span class="release__badge release__badge--red">Not migrated to EKS</span>
-<% end %>

--- a/data/ec2_deployed_apps.yml
+++ b/data/ec2_deployed_apps.yml
@@ -1,8 +1,0 @@
-- ckan
-- govuk_crawler_worker
-- licensify
-- licensify-admin
-- licensify-feed
-- puppet
-- service-manual-frontend
-- sidekiq-monitoring


### PR DESCRIPTION
This removes all the UI elements concerned with EC2 deployments and marks all apps are deployed to EKS. 

Didn't fully remove all logic for platform split, as require data migration - but this at least cleans up any confusion in the UI.