### PR TITLE
Revert "Fix CWE-352 CSRF protection weakness."

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
-  protect_from_forgery with: :exception
+  protect_from_forgery
 
   def error_400
     error 400


### PR DESCRIPTION
This reverts commit 1e65fb7662c9d301e701a0992d8b4a18efde4bb5. We memoize session data anywhere and aren't affected by this security issue right now. It's definitely sensible to throw an exception on missing/invalid CSRF token and protects against future code changes.  However, this behaviour breaks the deployment API when the request is authenticated via bearer token (because we don't need a CSRF token, but still check for one). To fix that we need implement a way to control the authentication strategies of gds-sso per controller - currently can only disable session authentication for whole Rails app.

Reverting this change as to fix the deployment API and allow Release to show up to date deployment information, whilst we work on gds-sso to remove the need for CSRF tokens for the deployment API.

#1375 