### PR TITLE
Get duplicate fields from the Developer Docs

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -114,7 +114,6 @@ private
       :id,
       :name,
       :default_branch,
-      :shortname,
       :status_notes,
       :task,
       :deploy_freeze,

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -61,7 +61,7 @@ class ApplicationsController < ApplicationController
 
     if @production_deploy
       comparison = Services.github.compare(
-        @application.repo,
+        @application.repo_path,
         @production_deploy.version,
         @release_tag,
       )
@@ -113,7 +113,6 @@ private
       :archived,
       :id,
       :name,
-      :repo,
       :default_branch,
       :shortname,
       :status_notes,

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -35,7 +35,7 @@ class DeploymentsController < ApplicationController
 private
 
   def application_by_repo
-    existing_apps = Application.where(repo: repo_path)
+    existing_apps = Application.where(name: repo_path)
 
     case existing_apps.length
     when 0
@@ -48,22 +48,12 @@ private
   end
 
   def repo_path
-    if params[:repo].start_with?("http")
-      URI.parse(params[:repo]).path.gsub(%r{^/}, "")
-    elsif params[:repo].start_with?("git@")
-      params[:repo].split(":")[-1].gsub(/.git$/, "")
-    else
-      params[:repo]
-    end
+    params[:repo].split("/")[-1]
   end
 
   def normalize_app_name(unnormalized_app_name)
     normalized_app_name = unnormalized_app_name.split("/")[-1].tr("-", " ").humanize.titlecase
     normalized_app_name.gsub(/\bApi\b/, "API")
-  end
-
-  def push_notification?
-    params[:repo].present?
   end
 
   def deployment_params
@@ -78,13 +68,6 @@ private
       :jenkins_user_name,
       :repo,
       :version,
-    )
-  end
-
-  def new_deployment_params
-    params.permit(
-      :application_id,
-      :environment,
     )
   end
 

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -39,7 +39,7 @@ private
 
     case existing_apps.length
     when 0
-      Application.create!(name: normalize_app_name(repo_path), repo: repo_path)
+      Application.create!(name: normalize_app_name(repo_path))
     when 1
       existing_apps[0]
     else

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -9,16 +9,20 @@ module UrlHelper
     "https://deploy.#{suffix}/job/Smokey"
   end
 
+  def github_repo_url(app)
+    Repo.url(app_name: app.name).nil? ? "https://github.com/alphagov/#{app.name.parameterize}" : Repo.url(app_name: app.name)
+  end
+
   def github_dependency_link_to(app, text)
-    link_to(text, "#{app.repo_url}/pulls?q=is%3Apr+state%3Aopen+label%3Adependencies", target: "_blank", rel: "noopener", class: "govuk-link")
+    link_to(text, "#{github_repo_url(app)}/pulls?q=is%3Apr+state%3Aopen+label%3Adependencies", target: "_blank", rel: "noopener", class: "govuk-link")
   end
 
   def github_tag_link_to(app, git_ref)
-    link_to(git_ref.truncate(15), "#{app.repo_url}/tree/#{git_ref}", target: "_blank", rel: "noopener", class: "govuk-link")
+    link_to(git_ref.truncate(15), "#{github_repo_url(app)}/tree/#{git_ref}", target: "_blank", rel: "noopener", class: "govuk-link")
   end
 
-  def github_compare_to_default(application, deploy)
-    "#{application.repo_url}/compare/#{deploy.version}...#{application.default_branch}"
+  def github_compare_to_default(app, deploy)
+    "#{github_repo_url(app)}/compare/#{deploy.version}...#{app.default_branch}"
   end
 
   def govuk_domain_suffix(environment)

--- a/app/jobs/post_out_of_sync_deploys_job.rb
+++ b/app/jobs/post_out_of_sync_deploys_job.rb
@@ -20,6 +20,6 @@ private
   end
 
   def app_info(app)
-    "- <#{Plek.external_url_for('release')}/applications/#{app.shortname}|#{app.name}> – #{app.status.to_s.humanize} (<https://github.com/#{app.repo}/actions/workflows/deploy.yml|Deploy GitHub action>)"
+    "- <#{Plek.external_url_for('release')}/applications/#{app.shortname}|#{app.name}> – #{app.status.to_s.humanize} (<https://github.com/#{app.repo_path}/actions/workflows/deploy.yml|Deploy GitHub action>)"
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,7 +5,7 @@ class Application < ApplicationRecord
 
   validates :name, presence: { message: "is required" }
 
-  validates :name, :status_notes, :shortname, length: { maximum: 255 }
+  validates :name, :status_notes, length: { maximum: 255 }
 
   validates :name, uniqueness: { case_sensitive: true }
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -52,11 +52,11 @@ class Application < ApplicationRecord
   end
 
   def repo_url
-    "https://github.com/#{repo}"
+    Repo.url(app_name: name).nil? ? "https://github.com/#{repo_path}" : Repo.url(app_name: name)
   end
 
   def repo_compare_url(from, to)
-    "https://github.com/#{repo}/compare/#{from}...#{to}"
+    "#{repo_url}/compare/#{from}...#{to}"
   end
 
   def self.cd_statuses

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -45,7 +45,7 @@ class Application < ApplicationRecord
   end
 
   def fallback_shortname
-    repo_path.split("/")[-1] unless repo_path.nil?
+    Repo.shortname(app_name: name).nil? ? name.parameterize : Repo.shortname(app_name: name)
   end
 
   def repo_path

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -7,7 +7,7 @@ class Commit
   end
 
   def github_url
-    "#{application.repo_url}/commit/#{commit_data[:sha]}"
+    "#{Repo.url(app_name: application.name)}/commit/#{commit_data[:sha]}"
   end
 
   def sha

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -27,7 +27,7 @@ class Deployment < ApplicationRecord
   def commits
     @commits ||=
       begin
-        Services.github.compare(application.repo, previous_version, version).commits.reverse.map do |commit|
+        Services.github.compare(application.repo_path, previous_version, version).commits.reverse.map do |commit|
           Commit.new(commit.to_h, application)
         end
       rescue Octokit::NotFound

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -3,14 +3,20 @@ class Repo
   base_uri "docs.publishing.service.gov.uk"
 
   def self.all
-    response ||= get("/apps.json")
-    JSON.parse(response.body)
-  rescue HTTParty::Error, JSON::ParserError => e
-    Rails.logger.debug "Error fetching govuk repos: #{e.message}"
-    []
+    Rails.cache.fetch("apps_json_data", expires_in: 12.hours) do
+      response ||= get("/apps.json")
+      JSON.parse(response.body)
+    rescue HTTParty::Error, JSON::ParserError => e
+      Rails.logger.debug "Error fetching govuk repos: #{e.message}"
+      []
+    end
   end
 
   def self.find_by(app_name:)
     all.find { |app| app["app_name"] == app_name.parameterize }
+  end
+
+  def self.url(app_name:)
+    find_by(app_name:)&.dig("links", "repo_url")
   end
 end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -19,4 +19,8 @@ class Repo
   def self.url(app_name:)
     find_by(app_name:)&.dig("links", "repo_url")
   end
+
+  def self.shortname(app_name:)
+    find_by(app_name:)&.dig("shortname")
+  end
 end

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -72,7 +72,7 @@
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-warning-text__assistive">Warning</span>
-            Continuous deployment between each environment has to be disabled or enabled via <%= link_to "GitHub action", "https://github.com/#{@application.repo}/actions/workflows/set-automatic-deploys.yml", class: "govuk-link" %>.
+            Continuous deployment between each environment has to be disabled or enabled via <%= link_to "GitHub action", "#{@application.repo_url}/actions/workflows/set-automatic-deploys.yml", class: "govuk-link" %>.
         </strong>
       </div>
     <% end %>

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -22,16 +22,6 @@
     end
   } %>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "Short name"
-    },
-    name: "application[shortname]",
-    hint: "For use in graphite metrics. Example: whitehall",
-    value: @application.shortname,
-    error_message: @application.errors[:shortname].first,
-  } %>
-
   <%= render "govuk_publishing_components/components/textarea", {
     label: {
       text: "Status notes"

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -8,16 +8,6 @@
     error_message: @application.errors[:name].first,
   } %>
 
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "GitHub repository path"
-    },
-    name: "application[repo]",
-    hint: "Example: alphagov/publisher",
-    value: @application.repo,
-    error_message: @application.errors[:repo].first,
-  } %>
-
   <%= render "govuk_publishing_components/components/select", {
     id: "default_branch",
     label: "GitHub repository default branch",

--- a/app/views/applications/deploy.html.erb
+++ b/app/views/applications/deploy.html.erb
@@ -23,7 +23,7 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: "Deploy this release",
-  href: "https://github.com/#{@application.repo}/actions/workflows/deploy.yml",
+  href: "#{@application.repo_url}/actions/workflows/deploy.yml",
   target: "_blank",
   margin_bottom: true
 } %>

--- a/db/migrate/20240208111830_remove_repo_column_from_application.rb
+++ b/db/migrate/20240208111830_remove_repo_column_from_application.rb
@@ -1,0 +1,8 @@
+class RemoveRepoColumnFromApplication < ActiveRecord::Migration[7.1]
+  def change
+    change_table :applications, bulk: true do |t|
+      t.remove_index :repo
+      t.remove :repo, type: :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_09_23_151609) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_111830) do
   create_table "applications", id: :integer, charset: "latin1", force: :cascade do |t|
     t.string "name"
-    t.string "repo"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "status_notes"
@@ -22,7 +21,6 @@ ActiveRecord::Schema[7.1].define(version: 2022_09_23_151609) do
     t.boolean "deploy_freeze", default: false, null: false
     t.string "default_branch", default: "main", null: false
     t.index ["name"], name: "index_applications_on_name", unique: true
-    t.index ["repo"], name: "index_applications_on_repo"
     t.index ["shortname"], name: "index_applications_on_shortname"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,20 +4,20 @@
 example_note = "Here is a note that will hopefully demonstrate how somebody might use the notes field to write a long note."
 
 applications = [
-  { name: "Calendars",                              repo: "alphagov/calendars" },
-  { name: "Content store",                          repo: "alphagov/content-store" },
-  { name: "Feedback",                               repo: "alphagov/feedback" },
-  { name: "Frontend",                               repo: "alphagov/frontend", status_notes: example_note },
-  { name: "Imminence",                              repo: "alphagov/imminence" },
-  { name: "Licensify",                              repo: "alphagov/licensify" },
-  { name: "Publisher",                              repo: "alphagov/publisher" },
-  { name: "Rummager",                               repo: "alphagov/rummager" },
-  { name: "Signon",                                 repo: "alphagov/signon" },
-  { name: "Smart answers",                          repo: "alphagov/smart-answers", shortname: "smartanswers" },
-  { name: "Static",                                 repo: "alphagov/static" },
-  { name: "Support",                                repo: "alphagov/support" },
-  { name: "Whitehall",                              repo: "alphagov/whitehall" },
-  { name: "Data insight non-govuk reach collector", repo: "alphagov/datainsight-nongovuk-reach-collector", archived: true },
+  { name: "Calendars" },
+  { name: "Content store" },
+  { name: "Feedback" },
+  { name: "Frontend", status_notes: example_note },
+  { name: "Imminence" },
+  { name: "Licensify" },
+  { name: "Publisher" },
+  { name: "Rummager" },
+  { name: "Signon" },
+  { name: "Smart answers", shortname: "smartanswers" },
+  { name: "Static" },
+  { name: "Support" },
+  { name: "Whitehall" },
+  { name: "Data insight non-govuk reach collector", archived: true },
 ]
 
 applications.each do |application_hash|

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :application do
     sequence(:name) { |n| "Application #{n}" }
-    sequence(:repo) { |n| "alphagov/application-#{n}" }
     status_notes { "" }
   end
 

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -294,11 +294,6 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select "form.edit_application input[name='application[name]'][value='#{@app.name}']"
     end
 
-    should "allow editing of the shortname in the form" do
-      get :edit, params: { id: @app.id }
-      assert_select "form.edit_application input[name='application[shortname]'][value='#{@app.shortname}']"
-    end
-
     should "show warning that an EKS deployed app has have deployments disabled via GitHub action" do
       get :edit, params: { id: @app.id }
       assert_select ".govuk-warning-text__text", /Continuous deployment between each environment has to be disabled or enabled * via GitHub action/

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -179,6 +179,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         @first_commit = stub_commit
         @second_commit = stub_commit
         @base_commit = stub_commit
+        stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
         FactoryBot.create(:deployment, application: @app, version:, deployed_sha: @first_commit[:sha])
         Octokit::Client.any_instance.stubs(:compare)
           .with(@app.repo_path, version, @app.default_branch)
@@ -336,6 +337,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "GET archived" do
     setup do
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
       @app1 = FactoryBot.create(:application, name: "app1")
       @app2 = FactoryBot.create(:application, name: "app2")
       @app3 = FactoryBot.create(:application, name: "app3", archived: true)

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -37,7 +37,7 @@ class DeploymentsControllerTest < ActionController::TestCase
 
   context "POST create" do
     should "create a deployment record" do
-      app = FactoryBot.create(:application, repo: "org/app")
+      app = FactoryBot.create(:application, name: "App")
       post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging", jenkins_user_email: "user@example.org", jenkins_user_name: "A User", deployed_sha: "02a570885766dc43d5e2432855bbffb342543906" } }
 
       deployment = app.reload.deployments.last
@@ -50,7 +50,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     end
 
     should "unarchive an archived application" do
-      app = FactoryBot.create(:application, repo: "org/app", archived: true)
+      app = FactoryBot.create(:application, name: "App", archived: true)
       post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging" } }
       app.reload
       assert_equal false, app.archived
@@ -95,15 +95,6 @@ class DeploymentsControllerTest < ActionController::TestCase
         post :create, params: { repo: "org/new-app", deployment: { version: "release_1", environment: "staging" } }
         app = Application.unscoped.last
         assert_equal "New App", app.name
-      end
-    end
-
-    context "handling multiple applications with the same repo" do
-      should "return a conflict response" do
-        FactoryBot.create(:application, name: "app 1", repo: "org/app")
-        FactoryBot.create(:application, name: "app 2", repo: "org/app")
-        post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging" } }
-        assert_response :conflict
       end
     end
   end

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -35,7 +35,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     end
   end
 
-  context "POST create" do
+  context "POST create using deployment information from Argo" do
     should "create a deployment record" do
       app = FactoryBot.create(:application, name: "App")
       post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging", jenkins_user_email: "user@example.org", jenkins_user_name: "A User", deployed_sha: "02a570885766dc43d5e2432855bbffb342543906" } }
@@ -54,22 +54,6 @@ class DeploymentsControllerTest < ActionController::TestCase
       post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging" } }
       app.reload
       assert_equal false, app.archived
-    end
-
-    context "accepting different 'repo' formats" do
-      should "accept a repo specified as a full URL" do
-        app = FactoryBot.create(:application, repo: "org/app")
-        assert_difference -> { app.deployments.count }, 1 do
-          post :create, params: { repo: "https://github.com/org/app", deployment: { version: "release_123", environment: "staging" } }
-        end
-      end
-
-      should "accept a repo specified as a git address" do
-        app = FactoryBot.create(:application, repo: "org/app")
-        assert_difference -> { app.deployments.count }, 1 do
-          post :create, params: { repo: "git@github.com:org/app.git", deployment: { version: "release_123", environment: "staging" } }
-        end
-      end
     end
 
     context "application doesn't exist" do

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -7,6 +7,7 @@ class DeploymentsControllerTest < ActionController::TestCase
 
   context "GET recent" do
     setup do
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
       Deployment.delete_all
       @application = FactoryBot.create(:application, name: "Foo")
       @deployments = FactoryBot.create_list(:deployment, 10, application_id: @application.id)
@@ -36,6 +37,10 @@ class DeploymentsControllerTest < ActionController::TestCase
   end
 
   context "POST create using deployment information from Argo" do
+    setup do
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
+    end
+
     should "create a deployment record" do
       app = FactoryBot.create(:application, name: "App")
       post :create, params: { repo: "org/app", deployment: { version: "release_123", environment: "staging", jenkins_user_email: "user@example.org", jenkins_user_name: "A User", deployed_sha: "02a570885766dc43d5e2432855bbffb342543906" } }

--- a/test/helpers/breadcrumb_helper_test.rb
+++ b/test/helpers/breadcrumb_helper_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BreadcrumbHelperTest < ActionView::TestCase
   should "return a hash of title and url" do
     app_name = SecureRandom.hex
-    app = FactoryBot.create(:application, name: app_name, repo: "alphagov/#{app_name}")
+    app = FactoryBot.create(:application, name: app_name)
 
     expected_hash = {
       title: app_name,

--- a/test/helpers/breadcrumb_helper_test.rb
+++ b/test/helpers/breadcrumb_helper_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class BreadcrumbHelperTest < ActionView::TestCase
   should "return a hash of title and url" do
+    stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
     app_name = SecureRandom.hex
     app = FactoryBot.create(:application, name: app_name)
 

--- a/test/integration/deploy_page_test.rb
+++ b/test/integration/deploy_page_test.rb
@@ -3,6 +3,7 @@ require "integration_test_helper"
 class DeployPageTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_user
+    stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
   end
 
   test "page handles a single deployment without a previous deployment" do

--- a/test/integration/deploy_page_test.rb
+++ b/test/integration/deploy_page_test.rb
@@ -28,16 +28,16 @@ class DeployPageTest < ActionDispatch::IntegrationTest
             "date": "2017-11-16T11:55:21Z",
           },
           "message": "Made a change to a thing. WIP! DO NOT DEPLOY!",
-          "url": "https://api.github.com/repos/#{application.repo}/git/commits/1234567890",
+          "url": "https://api.github.com/repos/#{application.repo_path}/git/commits/1234567890",
           "comment_count": 0,
         },
-        "url": "https://api.github.com/repos/#{application.repo}/commits/1234567890",
-        "html_url": "https://github.com/alphagov/#{application.repo}/1234567890",
-        "comments_url": "https://api.github.com/repos/#{application.repo}/commits/1234567890/comments",
+        "url": "https://api.github.com/repos/#{application.repo_path}/commits/1234567890",
+        "html_url": "https://github.com/alphagov/#{application.repo_path}/1234567890",
+        "comments_url": "https://api.github.com/repos/#{application.repo_path}/commits/1234567890/comments",
       },
     ]
 
-    stub_request(:get, "https://api.github.com/repos/#{application.repo}/compare/release_70...release_80")
+    stub_request(:get, "https://api.github.com/repos/#{application.repo_path}/compare/release_70...release_80")
       .to_return(headers: { "content-type" => "application/json" }, body: { commits: }.to_json)
 
     FactoryBot.create(:deployment, application:, environment: "production", version: "release_70")

--- a/test/integration/deploy_page_test.rb
+++ b/test/integration/deploy_page_test.rb
@@ -15,6 +15,7 @@ class DeployPageTest < ActionDispatch::IntegrationTest
   end
 
   test "page handles a deployment with a previous deployment" do
+    stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
     application = FactoryBot.create(:application)
 
     commits = [

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -2,6 +2,7 @@ require "integration_test_helper"
 
 class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
   setup do
+    stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
     @app1 = FactoryBot.create(:application)
     @app2 = FactoryBot.create(:application)
     login_as_stub_user

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -58,19 +58,19 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
   end
 
   def stub_deploy_and_release_page_api_requests_for(application, tag)
-    stub_request(:get, "https://api.github.com/repos/#{application.repo}/tags").to_return(body:
+    stub_request(:get, "https://api.github.com/repos/#{application.repo_path}/tags").to_return(body:
       [
         {
           "name": tag,
-          "zipball_url": "https://api.github.com/repos/#{application.repo}/zipball/#{tag}",
-          "tarball_url": "https://api.github.com/repos/#{application.repo}/tarball/#{tag}",
+          "zipball_url": "https://api.github.com/repos/#{application.repo_path}/zipball/#{tag}",
+          "tarball_url": "https://api.github.com/repos/#{application.repo_path}/tarball/#{tag}",
           "commit": {
             "sha": "1234567890",
-            "url": "https://api.github.com/repos/#{application.repo}/commits/f45771538251b6ec0d2cc88982797f28916a7878",
+            "url": "https://api.github.com/repos/#{application.repo_path}/commits/f45771538251b6ec0d2cc88982797f28916a7878",
           },
         },
       ])
-    stub_request(:get, "https://api.github.com/repos/#{application.repo}/commits").to_return(body:
+    stub_request(:get, "https://api.github.com/repos/#{application.repo_path}/commits").to_return(body:
       [
         {
           "sha": "1234567890",
@@ -81,18 +81,18 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
               "date": "2017-11-16T11:55:21Z",
             },
             "message": "Made a change to a thing. WIP! DO NOT DEPLOY!",
-            "url": "https://api.github.com/repos/#{application.repo}/git/commits/1234567890",
+            "url": "https://api.github.com/repos/#{application.repo_path}/git/commits/1234567890",
             "comment_count": 0,
           },
-          "url": "https://api.github.com/repos/#{application.repo}/commits/1234567890",
-          "html_url": "https://github.com/alphagov/#{application.repo}/1234567890",
-          "comments_url": "https://api.github.com/repos/#{application.repo}/commits/1234567890/comments",
+          "url": "https://api.github.com/repos/#{application.repo_path}/commits/1234567890",
+          "html_url": "https://github.com/alphagov/#{application.repo_path}/1234567890",
+          "comments_url": "https://api.github.com/repos/#{application.repo_path}/commits/1234567890/comments",
         },
       ])
     stub_request(:get, "https://grafana.dev.gov.uk:80/api/dashboards/file/#{application.shortname}.json").to_return(status: 200, body: "")
 
     Octokit::Client.any_instance.stubs(:search_issues)
-        .with("repo:#{application.repo} is:pr state:open label:dependencies")
+        .with("repo:#{application.repo_path} is:pr state:open label:dependencies")
         .returns({
           "total_count": 5,
         })

--- a/test/integration/stats_page_test.rb
+++ b/test/integration/stats_page_test.rb
@@ -12,6 +12,8 @@ class StatsPageTest < ActionDispatch::IntegrationTest
   end
 
   test "page with stats for an application" do
+    stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
+
     application = FactoryBot.create(:application)
 
     visit stats_application_path(application)

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -65,12 +65,6 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_equal "giraffe", application.shortname
     end
 
-    should "know its location on the internet" do
-      application = Application.new(@atts)
-
-      assert_equal "https://github.com/alphagov/tron-o-matic", application.repo_url
-    end
-
     should "default to not being archived" do
       application = Application.new(@atts)
 
@@ -278,6 +272,28 @@ class ApplicationTest < ActiveSupport::TestCase
       expected = { "production EKS" => production }
 
       assert_equal(expected.keys, app.latest_deploys_by_environment.keys)
+    end
+  end
+
+  context "existing application details from the Developer Docs" do
+    describe "#repo_url" do
+      should "return the repository url for the apps" do
+        response_body = [{ "app_name" => "account-api", "links" => { "repo_url" => "https://github.com/alphagov/account-api" } }].to_json
+        stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
+
+        app = FactoryBot.create(:application, name: "Account API")
+
+        assert_equal "https://github.com/alphagov/account-api", app.repo_url
+      end
+
+      should "create the repository url using the app name of the url is not provided or empty" do
+        response_body = [{ "app_name" => "account-api" }].to_json
+        stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
+
+        app = FactoryBot.create(:application, name: "Account API")
+
+        assert_equal "https://github.com/alphagov/account-api", app.repo_url
+      end
     end
   end
 

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -34,16 +34,6 @@ class ApplicationTest < ActiveSupport::TestCase
       assert application.errors[:name].include?("has already been taken")
     end
 
-    should "use the second half of the repo name as shortname if shortname not provided or empty" do
-      application = Application.create!(@atts)
-      assert_equal "tron-o-matic", application.shortname
-    end
-
-    should "use the provided shortname if not empty" do
-      application = Application.create!(@atts.merge(shortname: "giraffe"))
-      assert_equal "giraffe", application.shortname
-    end
-
     should "default to not being archived" do
       application = Application.new(@atts)
 
@@ -58,12 +48,6 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "be invalid with a name that is too long" do
       application = Application.new(@atts.merge(name: ("a" * 256)))
-
-      assert_not application.valid?
-    end
-
-    should "be invalid with a shortname that is too long" do
-      application = Application.new(@atts.merge(shortname: ("a" * 256)))
 
       assert_not application.valid?
     end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -7,7 +7,6 @@ class ApplicationTest < ActiveSupport::TestCase
     setup do
       @atts = {
         name: "Tron-o-matic",
-        repo: "alphagov/tron-o-matic",
       }
     end
 
@@ -35,26 +34,6 @@ class ApplicationTest < ActiveSupport::TestCase
       assert application.errors[:name].include?("has already been taken")
     end
 
-    should "be invalid with an invalid repo" do
-      application = Application.new(@atts)
-
-      application.repo = "noslashes"
-      assert_not application.valid?
-      assert application.errors[:repo].include?("is invalid")
-
-      application.repo = "too/many/slashes"
-      assert_not application.valid?
-      assert application.errors[:repo].include?("is invalid")
-
-      application.repo = "/slashatfront"
-      assert_not application.valid?
-      assert application.errors[:repo].include?("is invalid")
-
-      application.repo = "slashatback/"
-      assert_not application.valid?
-      assert application.errors[:repo].include?("is invalid")
-    end
-
     should "use the second half of the repo name as shortname if shortname not provided or empty" do
       application = Application.create!(@atts)
       assert_equal "tron-o-matic", application.shortname
@@ -79,12 +58,6 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "be invalid with a name that is too long" do
       application = Application.new(@atts.merge(name: ("a" * 256)))
-
-      assert_not application.valid?
-    end
-
-    should "be invalid with a repo that is too long" do
-      application = Application.new(@atts.merge(repo: "alphagov/my-r#{'e' * 243}po"))
 
       assert_not application.valid?
     end
@@ -141,7 +114,6 @@ class ApplicationTest < ActiveSupport::TestCase
     setup do
       @atts = {
         name: "Tron-o-matic",
-        repo: "alphagov/tron-o-matic",
       }
     end
 
@@ -176,10 +148,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
   context "live environment" do
     setup do
-      @atts = {
-        name: "Tron-o-matic",
-        repo: "alphagov/tron-o-matic",
-      }
+      @atts = { name: "Tron-o-matic" }
     end
 
     should "return production EKS" do
@@ -191,7 +160,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
   describe "#status" do
     before do
-      @app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
+      @app = FactoryBot.create(:application, name: SecureRandom.hex)
       Deployment.delete_all
     end
 

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -5,7 +5,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "return correct data" do
       Deployment.delete_all
 
-      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
+      app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include deploys from this month (it skews the graph)
       FactoryBot.create(:deployment, created_at: Time.zone.now, application: app, environment: "production")
@@ -31,7 +31,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "return correct data" do
       Deployment.delete_all
 
-      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
+      app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include staging deploys
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: app, environment: "staging")
@@ -58,8 +58,8 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "scope the results" do
       Deployment.delete_all
 
-      other_app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
-      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
+      other_app = FactoryBot.create(:application, name: SecureRandom.hex)
+      app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include other apps' deployments
       FactoryBot.create(:deployment, created_at: "2018-01-01", application: other_app, environment: "production")

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -5,6 +5,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "return correct data" do
       Deployment.delete_all
 
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include deploys from this month (it skews the graph)
@@ -31,6 +32,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "return correct data" do
       Deployment.delete_all
 
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include staging deploys
@@ -58,6 +60,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "scope the results" do
       Deployment.delete_all
 
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
       other_app = FactoryBot.create(:application, name: SecureRandom.hex)
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class DeploymentTest < ActiveSupport::TestCase
   describe "#previous_deployment" do
     should "should return the previous version" do
-      app = FactoryBot.create(:application, name: SecureRandom.hex, repo: "alphagov/#{SecureRandom.hex}")
+      app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       previous = FactoryBot.create(:deployment, application: app, environment: "staging")
       FactoryBot.create(:deployment, application: app, environment: "production")

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class DeploymentTest < ActiveSupport::TestCase
   describe "#previous_deployment" do
     should "should return the previous version" do
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       previous = FactoryBot.create(:deployment, application: app, environment: "staging")
@@ -15,6 +16,10 @@ class DeploymentTest < ActiveSupport::TestCase
   end
 
   describe "#commit_match?" do
+    before do
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
+    end
+
     should "return true when SHAs are the same" do
       deployment = FactoryBot.create(:deployment, deployed_sha: "c579613e5f0335ecf409fed881fa7919c150c1af")
 
@@ -47,6 +52,10 @@ class DeploymentTest < ActiveSupport::TestCase
   end
 
   describe "#to_live_environment?" do
+    before do
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
+    end
+
     should "return true if deployment to application's live environment" do
       deployment = FactoryBot.create(:deployment, environment: "production EKS")
 

--- a/test/unit/jobs/post_out_of_sync_deploys_job_test.rb
+++ b/test/unit/jobs/post_out_of_sync_deploys_job_test.rb
@@ -14,12 +14,12 @@ class PostOutOfSyncDeploysJobTest < ActiveJob::TestCase
 
     stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
 
-    app = FactoryBot.create(:application, name: "Account API", shortname: "account-api", repo: "alphagov/account-api")
+    app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
     FactoryBot.create(:deployment, application: app, version: "111", environment: "production EKS")
     FactoryBot.create(:deployment, application: app, version: "222", environment: "staging EKS")
     FactoryBot.create(:deployment, application: app, version: "222", environment: "integration EKS")
 
-    app2 = FactoryBot.create(:application, name: "Asset manager", shortname: "asset-manager", repo: "alphagov/asset-manager")
+    app2 = FactoryBot.create(:application, name: "Asset manager", shortname: "asset-manager")
     FactoryBot.create(:deployment, application: app2, version: "111", environment: "production EKS")
     FactoryBot.create(:deployment, application: app2, version: "111", environment: "staging EKS")
     FactoryBot.create(:deployment, application: app2, version: "222", environment: "integration EKS")
@@ -41,7 +41,7 @@ class PostOutOfSyncDeploysJobTest < ActiveJob::TestCase
     response_body = [{ "app_name" => "account-api", "team" => "#tech-content-interactions-on-platform-govuk" }].to_json
     stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
 
-    app = FactoryBot.create(:application, name: "Account API", shortname: "account-api", repo: "alphagov/account-api")
+    app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
     FactoryBot.create(:deployment, application: app, version: "222", environment: "production EKS")
     FactoryBot.create(:deployment, application: app, version: "222", environment: "staging EKS")
     FactoryBot.create(:deployment, application: app, version: "222", environment: "integration EKS")

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -23,4 +23,14 @@ class RepoTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe ".url" do
+    should "get the GitHub URL for a repository" do
+      response_body = [{ "app_name" => "account-api",
+                         "links" => { "repo_url" => "https://github.com/alphagov/account-api" } }].to_json
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
+
+      assert_equal "https://github.com/alphagov/account-api", Repo.url(app_name: "Account API")
+    end
+  end
 end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -33,4 +33,14 @@ class RepoTest < ActiveSupport::TestCase
       assert_equal "https://github.com/alphagov/account-api", Repo.url(app_name: "Account API")
     end
   end
+
+  describe ".shortname" do
+    should "get the shortname for a repository" do
+      response_body = [{ "app_name" => "account-api",
+                         "shortname" => "account_api" }].to_json
+      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
+
+      assert_equal "account_api", Repo.shortname(app_name: "account-api")
+    end
+  end
 end

--- a/test/unit/report/deploy_lag_report_test.rb
+++ b/test/unit/report/deploy_lag_report_test.rb
@@ -3,6 +3,7 @@ require "report/deploy_lag_report"
 
 class Report::DeployLagReportTest < ActiveSupport::TestCase
   setup do
+    stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
     @app = FactoryBot.create(:application)
     @start_date = 1.year.ago.strftime("%Y-%m-%d")
     @end_date = (Time.zone.today + 1).to_s


### PR DESCRIPTION
We now use the Developer Docs as the single source of truth for [information about repositories.](https://docs.publishing.service.gov.uk/apps.json)
This means it is no longer necessary to manually add information such as the repository url and shortname for apps as we can get this directly from the Dev docs. 
Please see individual commits for more detail.

This has been tested on Integration - see screenshots below.

Edit app form (before):

<img width="1254" alt="Screenshot 2024-02-14 at 15 56 22" src="https://github.com/alphagov/release/assets/19667619/3bfcfd2f-4807-479e-937a-8f15d0e44721">

Edit app form (after):

<img width="1024" alt="Screenshot 2024-02-14 at 15 54 39" src="https://github.com/alphagov/release/assets/19667619/048815c5-a186-4d10-ae89-aa33bb220b8d">

New app form (before):

<img width="1242" alt="Screenshot 2024-02-14 at 16 05 11" src="https://github.com/alphagov/release/assets/19667619/203ffaca-0dc4-4d29-9af3-c3dfe347cfd3">

New app form (after):

<img width="1014" alt="Screenshot 2024-02-14 at 16 04 52" src="https://github.com/alphagov/release/assets/19667619/9e02dce0-d1d1-4dba-bf4f-84aa15b91b9c">


Trello card: https://trello.com/c/PUsKqIyq/3396-3-remove-duplicate-fields-from-release-app
