### PR TITLE
Clear application and deployments before tests are run

### DIFF
--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -238,6 +238,11 @@ class ApplicationTest < ActiveSupport::TestCase
   end
 
   context "existing application details from the Developer Docs" do
+    setup do
+      Application.delete_all
+      Application.delete_all
+    end
+
     describe "#repo_url" do
       should "return the repository url for the apps" do
         response_body = [{ "app_name" => "account-api", "links" => { "repo_url" => "https://github.com/alphagov/account-api" } }].to_json
@@ -259,6 +264,11 @@ class ApplicationTest < ActiveSupport::TestCase
     end
 
     describe "#fallback_shortname" do
+      before do
+        Application.delete_all
+        Application.delete_all
+      end
+
       should "return the shortname for the app" do
         response_body = [{ "app_name" => "account-api", "shortname" => "account_api" }].to_json
         stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)


### PR DESCRIPTION
This was missed in https://github.com/alphagov/release/pull/1401 and is failing on main:

```
Error:
ApplicationTest#test_: existing application details from the Developer Docs should return the shortname for the app. :
RuntimeError: Neutered Exception ActiveRecord::RecordInvalid: Validation failed: Name has already been taken
    test/unit/application_test.rb:266:in `block (3 levels) in <class:ApplicationTest>'
    test/unit/application_test.rb:270:in `instance_exec'
    test/unit/application_test.rb:270:in `block in create_test_from_should_hash'

bin/rails test test/unit/application_test.rb:262
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
