### PR TITLE
Remove EKS suffix from the environments

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -17,7 +17,7 @@ class DeploymentsController < ApplicationController
   def recent
     env = recent_deployment_params[:environment_filter]
 
-    filtered_deployments = env ? Deployment.where(environment: [env, "#{env} EKS"]) : Deployment
+    filtered_deployments = env ? Deployment.where(environment: env) : Deployment
     @deployments = filtered_deployments.includes(:application).newest_first.limit(25)
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -20,7 +20,7 @@ class Application < ApplicationRecord
   ENVIRONMENTS_ORDER = %w[integration staging production].freeze
 
   def latest_deploys_by_environment
-    @latest_deploys_by_environment ||= ENVIRONMENTS_ORDER.map { |env| "#{env} EKS" }
+    @latest_deploys_by_environment ||= ENVIRONMENTS_ORDER
       .index_with { |environment| deployments.last_deploy_to(environment) }
       .compact
   end
@@ -36,7 +36,6 @@ class Application < ApplicationRecord
 
   def status
     envs = %w[production staging integration]
-    envs = envs.map { |env| "#{env} EKS" }
 
     return :production_and_staging_not_in_sync unless in_sync?(envs.take(2))
     return :undeployed_changes_in_integration unless in_sync?(envs)
@@ -110,7 +109,7 @@ class Application < ApplicationRecord
   end
 
   def live_environment
-    "production EKS"
+    "production"
   end
 
   def team_name

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -44,7 +44,7 @@
           <%= t.cell application_status %>
 
           <% @environments.each do |environment| %>
-            <% environment = environment + " EKS" unless application.deployed_to_ec2? %>
+            <% environment = environment + " EKS" %>
             <% latest_deploy = application.latest_deploys_by_environment[environment] %>
             <% env_deploy = capture do %>
               <% if latest_deploy %>

--- a/app/views/applications/_applications_table.html.erb
+++ b/app/views/applications/_applications_table.html.erb
@@ -44,7 +44,6 @@
           <%= t.cell application_status %>
 
           <% @environments.each do |environment| %>
-            <% environment = environment + " EKS" %>
             <% latest_deploy = application.latest_deploys_by_environment[environment] %>
             <% env_deploy = capture do %>
               <% if latest_deploy %>

--- a/db/migrate/20240221154421_remove_eks_suffix_from_environment_names.rb
+++ b/db/migrate/20240221154421_remove_eks_suffix_from_environment_names.rb
@@ -1,0 +1,13 @@
+class RemoveEksSuffixFromEnvironmentNames < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      UPDATE deployments
+      SET environment = REGEXP_REPLACE(environment, ' EKS$', '')
+      WHERE environment LIKE '% EKS';
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_111830) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_21_154421) do
   create_table "applications", id: :integer, charset: "latin1", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil, null: false

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
   factory :deployment do
     sequence(:version) { |n| "release_#{n}" }
-    environment { "production EKS" }
+    environment { "production" }
     application
   end
 

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -16,7 +16,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       @deploy1 = FactoryBot.create(
         :deployment,
         application: @app1,
-        environment: "staging EKS",
+        environment: "staging",
         version: "release_x",
       )
     end
@@ -145,9 +145,9 @@ class ApplicationsControllerTest < ActionController::TestCase
         @manual_deploy = SecureRandom.hex(40)
         @latest_commit = { sha: @manual_deploy, commit: { author: { name: "Winston Churchill" }, message: "We shall fight on the beaches" } }
 
-        FactoryBot.create(:deployment, application: @app, environment: "production EKS", version:, deployed_sha: @deployed_sha)
-        FactoryBot.create(:deployment, application: @app, environment: "staging EKS", version:, deployed_sha: @deployed_sha)
-        FactoryBot.create(:deployment, application: @app, environment: "integration EKS", version: @manual_deploy)
+        FactoryBot.create(:deployment, application: @app, environment: "production", version:, deployed_sha: @deployed_sha)
+        FactoryBot.create(:deployment, application: @app, environment: "staging", version:, deployed_sha: @deployed_sha)
+        FactoryBot.create(:deployment, application: @app, environment: "integration", version: @manual_deploy)
 
         stub_request(:get, "https://api.github.com/repos/#{@app.repo_path}/commits/#{@manual_deploy}").to_return(headers: { "Content-Type" => "application/json" }, body: JSON.generate(@latest_commit))
 
@@ -162,7 +162,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
       should "show the manual deployment commit" do
         get :show, params: { id: @app.id }
-        assert_select ".release__commits-label", { text: "Integration eks", count: 1 }
+        assert_select ".release__commits-label", { text: "Integration", count: 1 }
         assert_select "p", text: @latest_commit[:message]
         assert_select ".release__commit-hash", { text: @manual_deploy.first(9), count: 1 }
       end
@@ -295,7 +295,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       assert_select "form.edit_application input[name='application[name]'][value='#{@app.name}']"
     end
 
-    should "show warning that an EKS deployed app has have deployments disabled via GitHub action" do
+    should "show warning that an deployed app has have deployments disabled via GitHub action" do
       get :edit, params: { id: @app.id }
       assert_select ".govuk-warning-text__text", /Continuous deployment between each environment has to be disabled or enabled * via GitHub action/
     end

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -27,7 +27,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     end
 
     should "assign only filtered environments" do
-      FactoryBot.create(:deployment, application_id: @application.id, environment: "integration EKS")
+      FactoryBot.create(:deployment, application_id: @application.id, environment: "integration")
       FactoryBot.create(:deployment, application_id: @application.id, environment: "integration")
 
       get :recent, params: { environment_filter: "Integration" }

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -125,14 +125,6 @@ class ApplicationTest < ActiveSupport::TestCase
     end
   end
 
-  context "deployed to EC2" do
-    should "return false" do
-      stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
-      application = Application.new(@atts)
-      assert_not application.deployed_to_ec2?
-    end
-  end
-
   context "live environment" do
     setup do
       @atts = { name: "Tron-o-matic" }

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -131,10 +131,10 @@ class ApplicationTest < ActiveSupport::TestCase
       stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: "", headers: {})
     end
 
-    should "return production EKS" do
+    should "return production" do
       application = Application.new(@atts)
 
-      assert_equal "production EKS", application.live_environment
+      assert_equal "production", application.live_environment
     end
   end
 
@@ -146,25 +146,25 @@ class ApplicationTest < ActiveSupport::TestCase
     end
 
     should "return :all_environments_match when deployments are in sync" do
-      FactoryBot.create(:deployment, application: @app, version: "1", environment: "integration EKS")
-      FactoryBot.create(:deployment, application: @app, version: "1", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: @app, version: "1", environment: "production EKS")
+      FactoryBot.create(:deployment, application: @app, version: "1", environment: "integration")
+      FactoryBot.create(:deployment, application: @app, version: "1", environment: "staging")
+      FactoryBot.create(:deployment, application: @app, version: "1", environment: "production")
 
       assert_equal :all_environments_match, @app.status
     end
 
     should "return :production_and_staging_not_in_sync when staging and production have different versions" do
-      FactoryBot.create(:deployment, application: @app, version: "2", environment: "integration EKS")
-      FactoryBot.create(:deployment, application: @app, version: "2", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: @app, version: "1", environment: "production EKS")
+      FactoryBot.create(:deployment, application: @app, version: "2", environment: "integration")
+      FactoryBot.create(:deployment, application: @app, version: "2", environment: "staging")
+      FactoryBot.create(:deployment, application: @app, version: "1", environment: "production")
 
       assert_equal :production_and_staging_not_in_sync, @app.status
     end
 
     should "return :undeployed_changes_in_integration when there are different version across the environments" do
-      FactoryBot.create(:deployment, application: @app, version: "2", environment: "integration EKS")
-      FactoryBot.create(:deployment, application: @app, version: "1", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: @app, version: "1", environment: "production EKS")
+      FactoryBot.create(:deployment, application: @app, version: "2", environment: "integration")
+      FactoryBot.create(:deployment, application: @app, version: "1", environment: "staging")
+      FactoryBot.create(:deployment, application: @app, version: "1", environment: "production")
 
       assert_equal :undeployed_changes_in_integration, @app.status
     end
@@ -181,14 +181,14 @@ class ApplicationTest < ActiveSupport::TestCase
 
       app = FactoryBot.create(:application)
 
-      production = FactoryBot.create(:deployment, application: app, environment: "production EKS")
-      staging = FactoryBot.create(:deployment, application: app, environment: "staging EKS")
-      integration = FactoryBot.create(:deployment, application: app, environment: "integration EKS")
+      production = FactoryBot.create(:deployment, application: app, environment: "production")
+      staging = FactoryBot.create(:deployment, application: app, environment: "staging")
+      integration = FactoryBot.create(:deployment, application: app, environment: "integration")
 
       expected = {
-        "integration EKS" => integration,
-        "staging EKS" => staging,
-        "production EKS" => production,
+        "integration" => integration,
+        "staging" => staging,
+        "production" => production,
       }
 
       assert_equal(expected.keys, app.latest_deploys_by_environment.keys)
@@ -202,14 +202,14 @@ class ApplicationTest < ActiveSupport::TestCase
 
       FactoryBot.create(:deployment, application: app, environment: "training")
       FactoryBot.create(:deployment, application: app, environment: "preview")
-      production = FactoryBot.create(:deployment, application: app, environment: "production EKS")
-      staging = FactoryBot.create(:deployment, application: app, environment: "staging EKS")
-      integration = FactoryBot.create(:deployment, application: app, environment: "integration EKS")
+      production = FactoryBot.create(:deployment, application: app, environment: "production")
+      staging = FactoryBot.create(:deployment, application: app, environment: "staging")
+      integration = FactoryBot.create(:deployment, application: app, environment: "integration")
 
       expected = {
-        "integration EKS" => integration,
-        "staging EKS" => staging,
-        "production EKS" => production,
+        "integration" => integration,
+        "staging" => staging,
+        "production" => production,
       }
 
       assert_equal(expected.keys, app.latest_deploys_by_environment.keys)
@@ -221,9 +221,9 @@ class ApplicationTest < ActiveSupport::TestCase
 
       app = FactoryBot.create(:application)
 
-      production = FactoryBot.create(:deployment, application: app, environment: "production EKS")
+      production = FactoryBot.create(:deployment, application: app, environment: "production")
 
-      expected = { "production EKS" => production }
+      expected = { "production" => production }
 
       assert_equal(expected.keys, app.latest_deploys_by_environment.keys)
     end
@@ -315,19 +315,19 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "return the apps that are out of sync" do
       app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
-      FactoryBot.create(:deployment, application: app, version: "111", environment: "production EKS")
-      FactoryBot.create(:deployment, application: app, version: "111", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: app, version: "222", environment: "integration EKS")
+      FactoryBot.create(:deployment, application: app, version: "111", environment: "production")
+      FactoryBot.create(:deployment, application: app, version: "111", environment: "staging")
+      FactoryBot.create(:deployment, application: app, version: "222", environment: "integration")
 
       app2 = FactoryBot.create(:application, name: "Asset manager", shortname: "asset-manager")
-      FactoryBot.create(:deployment, application: app2, version: "111", environment: "production EKS")
-      FactoryBot.create(:deployment, application: app2, version: "222", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: app2, version: "222", environment: "integration EKS")
+      FactoryBot.create(:deployment, application: app2, version: "111", environment: "production")
+      FactoryBot.create(:deployment, application: app2, version: "222", environment: "staging")
+      FactoryBot.create(:deployment, application: app2, version: "222", environment: "integration")
 
       app3 = FactoryBot.create(:application, name: "Release", shortname: "release")
-      FactoryBot.create(:deployment, application: app3, version: "222", environment: "production EKS")
-      FactoryBot.create(:deployment, application: app3, version: "222", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: app3, version: "222", environment: "integration EKS")
+      FactoryBot.create(:deployment, application: app3, version: "222", environment: "production")
+      FactoryBot.create(:deployment, application: app3, version: "222", environment: "staging")
+      FactoryBot.create(:deployment, application: app3, version: "222", environment: "integration")
 
       assert_equal [app, app2], Application.out_of_sync
     end
@@ -335,9 +335,9 @@ class ApplicationTest < ActiveSupport::TestCase
     should "not include apps which have been archived" do
       app = FactoryBot.create(:application, name: "Manuals frontend", archived: true)
 
-      FactoryBot.create(:deployment, application: app, version: "111", environment: "production EKS")
-      FactoryBot.create(:deployment, application: app, version: "111", environment: "staging EKS")
-      FactoryBot.create(:deployment, application: app, version: "222", environment: "integration EKS")
+      FactoryBot.create(:deployment, application: app, version: "111", environment: "production")
+      FactoryBot.create(:deployment, application: app, version: "111", environment: "staging")
+      FactoryBot.create(:deployment, application: app, version: "222", environment: "integration")
 
       assert_equal [], Application.out_of_sync
     end

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -57,7 +57,7 @@ class DeploymentTest < ActiveSupport::TestCase
     end
 
     should "return true if deployment to application's live environment" do
-      deployment = FactoryBot.create(:deployment, environment: "production EKS")
+      deployment = FactoryBot.create(:deployment, environment: "production")
 
       assert_equal true, deployment.to_live_environment?
     end

--- a/test/unit/jobs/post_out_of_sync_deploys_job_test.rb
+++ b/test/unit/jobs/post_out_of_sync_deploys_job_test.rb
@@ -15,14 +15,14 @@ class PostOutOfSyncDeploysJobTest < ActiveJob::TestCase
     stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
 
     app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
-    FactoryBot.create(:deployment, application: app, version: "111", environment: "production EKS")
-    FactoryBot.create(:deployment, application: app, version: "222", environment: "staging EKS")
-    FactoryBot.create(:deployment, application: app, version: "222", environment: "integration EKS")
+    FactoryBot.create(:deployment, application: app, version: "111", environment: "production")
+    FactoryBot.create(:deployment, application: app, version: "222", environment: "staging")
+    FactoryBot.create(:deployment, application: app, version: "222", environment: "integration")
 
     app2 = FactoryBot.create(:application, name: "Asset manager", shortname: "asset-manager")
-    FactoryBot.create(:deployment, application: app2, version: "111", environment: "production EKS")
-    FactoryBot.create(:deployment, application: app2, version: "111", environment: "staging EKS")
-    FactoryBot.create(:deployment, application: app2, version: "222", environment: "integration EKS")
+    FactoryBot.create(:deployment, application: app2, version: "111", environment: "production")
+    FactoryBot.create(:deployment, application: app2, version: "111", environment: "staging")
+    FactoryBot.create(:deployment, application: app2, version: "222", environment: "integration")
 
     PostOutOfSyncDeploysJob.perform_now
 
@@ -42,9 +42,9 @@ class PostOutOfSyncDeploysJobTest < ActiveJob::TestCase
     stub_request(:get, "http://docs.publishing.service.gov.uk/apps.json").to_return(status: 200, body: response_body)
 
     app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
-    FactoryBot.create(:deployment, application: app, version: "222", environment: "production EKS")
-    FactoryBot.create(:deployment, application: app, version: "222", environment: "staging EKS")
-    FactoryBot.create(:deployment, application: app, version: "222", environment: "integration EKS")
+    FactoryBot.create(:deployment, application: app, version: "222", environment: "production")
+    FactoryBot.create(:deployment, application: app, version: "222", environment: "staging")
+    FactoryBot.create(:deployment, application: app, version: "222", environment: "integration")
 
     assert_no_enqueued_jobs do
       PostOutOfSyncDeploysJob.perform_now


### PR DESCRIPTION
This cleans up the code added to support environments that were prefixed with "EKS" during the migration. This also has a migration to normalise the data.

Tested in integration.