### PR TITLE
Test the multi-arch workflow on the release app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG ruby_version=3.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
-FROM $builder_image AS builder
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
@@ -14,7 +14,7 @@ RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 
 
-FROM $base_image
+FROM --platform=$TARGETPLATFORM $base_image
 
 ENV GOVUK_APP_NAME=release
 


### PR DESCRIPTION
## What?
This swaps the used GH Workflow to the multi-arch one so we can start building ARM64-based images.

## Why?
ARM is the future and we'd like to start testing it. Release seems like a "low impact" app that we can safely test changes like this before rolling out a wider test.

(I'm unsure of how useful this particular app will be to test, however, as I'm not convinced that it works properly outside of Production!)

## How?
Once this is merged, we should start seeing Docker images for both AMD64 and ARM64 architecture systems - Docker is smart enough to automatically pull the correct architecture image for the system that is requesting it.

Once we have a few apps built for testing, we can begin small scale tests on Integration with Graviton "tainted" Nodes and see what happens.