### PR TITLE
Increase page width to 1140px

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
+$govuk-page-width: 1140px;
 $govuk-typography-use-rem: false;
 
 @import "govuk_publishing_components/all_components";


### PR DESCRIPTION
This allows for more space to display the applications table, which was overflowing due to the notes section.
