### PR TITLE
Use commit history instead of compare API call

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,14 +19,7 @@ class ApplicationsController < ApplicationController
       format.json { render json: @application }
       format.html do
         @outstanding_dependency_pull_requests = @application.dependency_pull_requests[:total_count]
-
-        @tag_names_by_commit = @application.tag_names_by_commit
-
-        @commits = if @application.deployments.last_deploy_to(@application.live_environment)
-                     @application.undeployed_commits
-                   else
-                     @application.commits
-                   end
+        @commits = @application.commit_history
 
         @github_available = true
       rescue Octokit::TooManyRequests

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -25,23 +25,19 @@
       <%= t.body do %>
         <% @commits.each do |commit| %>
           <%= t.row do %>
-            <% tags = @tag_names_by_commit.fetch(commit[:sha], []) %>
             <% commit_deployments = capture do %>
-              <% @application.latest_deploys_by_environment.each do |environment, deployment| %>
-                <% if tags.include?(deployment.version) || deployment.commit_match?(commit[:sha]) %>
-                  <% latest_deploy_on_default_branch << environment %>
-                  <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
-                    <span class="release__commits-label release__commits-label--<%= 'production' if deployment.to_live_environment? %>"><%= deployment.environment.humanize %></span>
-                    <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
-                  </p>
-                <% end %>
+              <% commit[:deployed_to].each do |deployment| %>
+                <p class="govuk-body-xs govuk-!-margin-bottom-1 release__commits-message">
+                  <span class="release__commits-label release__commits-label--<%= 'production' if deployment.to_live_environment? %>"><%= deployment.environment.humanize %></span>
+                  <span>at <%= time_tag(deployment.created_at, human_datetime(deployment.created_at)) %></span>
+                </p>
               <% end %>
             <% end %>
 
             <%= t.cell commit_deployments || "" %>
 
             <% commit_tags = capture do %>
-              <% tags.each do |tag| %>
+              <% commit[:tags].each do |tag| %>
                 <a class="govuk-link govuk-body-s" href="<%= deploy_application_path(@application) %>?tag=<%= tag %>"><%= tag %></a>
               <% end %>
             <% end %>
@@ -50,17 +46,17 @@
 
             <% commit_message = capture do %>
               <p class="govuk-body-s govuk-!-margin-bottom-0">
-                <%= commit[:commit][:message].split(/\n/)[0] %>
-                <% if commit[:commit][:author] %>
+                <%= commit[:message] %>
+                <% if commit[:author] %>
                   <span class="release__commits-author">
-                    <%= commit[:commit][:author][:name] %>
+                    <%= commit[:author] %>
                   </span>
                 <% end %>
               </p>
             <% end %>
 
             <%= t.cell commit_message %>
-            <%= t.cell link_to(commit[:sha][0..8], "#{@application.repo_url}/commit/#{commit[:sha]}", target: "_blank", class: "release__commit-hash govuk-link govuk-body-s") %>
+            <%= t.cell link_to(commit[:sha][0..8], commit[:github_url], target: "_blank", class: "release__commit-hash govuk-link govuk-body-s") %>
           <% end %>
         <% end %>
       <% end %>
@@ -110,8 +106,8 @@
   <%= t.body do %>
     <% @application.latest_deploys_by_environment.each do |environment, deployment| %>
       <% not_on_default_branch = capture do %>
-        <% unless latest_deploy_on_default_branch.include?(environment) %>
-            <span class="release__badge release__badge--orange">Not on default branch</span>
+        <% unless @application.environment_on_default_branch(environment)  %>
+          <span class="release__badge release__badge--orange">Not on default branch</span>
         <% end %>
       <% end %>
       <%= t.row do %>

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -70,7 +70,7 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
           },
         },
       ])
-    stub_request(:get, "https://api.github.com/repos/#{application.repo_path}/commits").to_return(body:
+    stub_request(:get, "https://api.github.com/repos/#{application.repo_path}/commits?per_page=50").to_return(body:
       [
         {
           "sha": "1234567890",


### PR DESCRIPTION
This simplifies the logic for generating the commit log on the an application page, and moves logic from the view to the model.

Instead of using the commit comparision API, we simply just get the commit history for the last 50 commits. Then filter out the relevant commits.