### PR TITLE
Allow auto-merging of external dependencies

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,3 +1,4 @@
 api_version: 2
 defaults:
   auto_merge: true
+  update_external_dependencies: true


### PR DESCRIPTION
The test coverage is now 97%.

[Trello](https://trello.com/c/lYEw0975/3507-improve-test-coverage-in-release-app-and-enable-auto-merging-external-dependencies-3)