### PR TITLE
Fix build failure on yarn install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY package.json yarn.lock ./
-RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+RUN yarn install --immutable
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
Fixes builds aborting on spurious `Your lockfile needs to be updated, but yarn was run with --frozen-lockfile`. Dunno how the flags ended up out of sync with the flavour of Yarn 🤷 The new flags are the ones that work elsewhere e.g. alphagov/government-frontend/Dockerfile.