### PR TITLE
Clean up the tests a bit.

### DIFF
--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -9,7 +9,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     setup do
       response_body = [{ "app_name" => "app1",
                          "links" => { "repo_url" => "https://github.com/user/app1" } }].to_json
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body, headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
       @app1 = FactoryBot.create(:application, name: "app1", default_branch: "main")
       @app2 = FactoryBot.create(:application, name: "app2")
       @deploy1 = FactoryBot.create(
@@ -45,7 +45,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "POST create" do
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     context "valid request" do
@@ -87,7 +87,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "GET show" do
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
 
       @app = FactoryBot.create(:application)
       stub_graphql(Github, :application, owner: "alphagov", name: @app.name.parameterize)
@@ -152,7 +152,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         @first_commit = "ee37124a286a0b8501776d9bbe55dcb18ccab645"
         @second_commit = "1dac538d10b181e9b7b46766bc3a72d001a1f703"
         @base_commit = "974d1aedf82c068b42dace07984025fd70dfb240"
-        stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+        stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
         FactoryBot.create(:deployment, application: @app, version:, deployed_sha: @first_commit)
       end
 
@@ -183,7 +183,7 @@ class ApplicationsControllerTest < ActionController::TestCase
     context "when format is json" do
       setup do
         response_body = [{ "app_name" => "application-2", "links" => { "repo_url" => "https://github.com/alphagov/application-2" } }].to_json
-        stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body, headers: {})
+        stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body:)
         @app = FactoryBot.create(:application, name: "Application 2")
       end
 
@@ -224,7 +224,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "GET edit" do
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       @app = FactoryBot.create(:application, name: "monkeys")
     end
 
@@ -241,7 +241,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "PUT update" do
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       @app = FactoryBot.create(:application)
     end
 
@@ -275,7 +275,7 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "GET deploy" do
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       @app = FactoryBot.create(:application, name: "app1", status_notes: "Do not deploy this without talking to core team first!")
       @deployment = FactoryBot.create(:deployment, application_id: @app.id, created_at: "18/01/2013 11:57")
       @release_tag = "hot_fix_1"

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -163,14 +163,9 @@ class ApplicationsControllerTest < ActionController::TestCase
 
       should "set the commit history in reverse order" do
         get :show, params: { id: @app.id }
-
-        # `assigns` in Rails silently converts hashes to
-        # HashWithIndifferentAccess instances, so we can't simply compare for
-        # equality on the objects themselves
-        assert_equal(
-          [@second_commit, @first_commit],
-          assigns[:commits].take(2).map { |commit| commit[:sha] },
-        )
+        expected = [@second_commit, @first_commit]
+        actual = assigns[:commits].pluck(:sha)
+        assert_equal(expected, actual)
       end
 
       should "include the base commit" do

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -7,8 +7,10 @@ class ApplicationsControllerTest < ActionController::TestCase
 
   context "GET index" do
     setup do
-      response_body = [{ "app_name" => "app1",
-                         "links" => { "repo_url" => "https://github.com/user/app1" } }].to_json
+      response_body = [{
+        "app_name" => "app1",
+        "links" => { "repo_url" => "https://github.com/user/app1" },
+      }].to_json
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
       @app1 = FactoryBot.create(:application, name: "app1", default_branch: "main")
       @app2 = FactoryBot.create(:application, name: "app2")
@@ -52,21 +54,13 @@ class ApplicationsControllerTest < ActionController::TestCase
       should "create an application" do
         assert_difference "Application.count", 1 do
           post :create,
-               params: {
-                 application: {
-                   name: "My First App",
-                 },
-               }
+               params: { application: { name: "My First App" } }
         end
       end
 
       should "redirect to the application" do
         post :create,
-             params: {
-               application: {
-                 name: "My First App",
-               },
-             }
+             params: { application: { name: "My First App" } }
         assert_redirected_to application_path(Application.last)
       end
     end
@@ -170,14 +164,16 @@ class ApplicationsControllerTest < ActionController::TestCase
 
       should "include the base commit" do
         get :show, params: { id: @app.id }
-
         assert_equal @first_commit, assigns[:commits].last[:sha]
       end
     end
 
     context "when format is json" do
       setup do
-        response_body = [{ "app_name" => "application-2", "links" => { "repo_url" => "https://github.com/alphagov/application-2" } }].to_json
+        body = [{
+          "app_name" => "application-2",
+          "links" => { "repo_url" => "https://github.com/alphagov/application-2" },
+        }].to_json
         stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body:)
         @app = FactoryBot.create(:application, name: "Application 2")
       end
@@ -280,16 +276,11 @@ class ApplicationsControllerTest < ActionController::TestCase
 
       Octokit::Client.any_instance.stubs(:compare)
         .with(@app.repo_path, @deployment.version, @release_tag)
-        .returns(stub(
-                   "comparison",
-                   commits: [],
-                   base_commit: nil,
-                 ))
+        .returns(stub("comparison", commits: [], base_commit: nil))
       Plek.any_instance
         .stubs(:external_url_for)
         .with("signon")
         .returns("https://signon_hostname")
-
       Plek.any_instance
         .stubs(:external_url_for)
         .with("grafana")
@@ -348,9 +339,7 @@ private
     {
       sha: random_sha,
       login: "winston",
-      commit: {
-        message: "Hi",
-      },
+      commit: { message: "Hi" },
     }
   end
 end

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -250,7 +250,7 @@ class ApplicationsControllerTest < ActionController::TestCase
         put :update, params: { id: @app.id, application: { name: "new name", deploy_freeze: true } }
         @app.reload
         assert_equal "new name", @app.name
-        assert_equal true, @app.deploy_freeze?
+        assert @app.deploy_freeze?
       end
 
       should "redirect to the application" do

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -7,7 +7,7 @@ class DeploymentsControllerTest < ActionController::TestCase
 
   context "GET recent" do
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       Deployment.delete_all
       @application = FactoryBot.create(:application, name: "Foo")
       @deployments = FactoryBot.create_list(:deployment, 10, application_id: @application.id)
@@ -57,7 +57,7 @@ class DeploymentsControllerTest < ActionController::TestCase
     end
 
     setup do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     should "create a deployment record" do

--- a/test/functional/deployments_controller_test.rb
+++ b/test/functional/deployments_controller_test.rb
@@ -15,23 +15,19 @@ class DeploymentsControllerTest < ActionController::TestCase
 
     should "render the recent template" do
       get :recent
-
       assert_template "recent"
       assert response.ok?
     end
 
     should "assign deployments to the template" do
       get :recent
-
       assert_equal 10, assigns(:deployments).size
     end
 
     should "assign only filtered environments" do
       FactoryBot.create(:deployment, application_id: @application.id, environment: "integration")
       FactoryBot.create(:deployment, application_id: @application.id, environment: "integration")
-
       get :recent, params: { environment_filter: "Integration" }
-
       assert_equal 2, assigns(:deployments).size
     end
   end
@@ -44,14 +40,19 @@ class DeploymentsControllerTest < ActionController::TestCase
 
       should "enable forgery protection for non-API requests" do
         assert_raises(ActionController::InvalidAuthenticityToken) do
-          post :create, params: { repo: "org/app", deployment: { version: "1", environment: "env" } }
+          post :create, params: {
+            repo: "org/app",
+            deployment: { version: "1", environment: "env" },
+          }
         end
       end
 
       should "skip forgery protection for API requests" do
         request.headers["Authorization"] = "Bearer <token>"
-        post :create, params: { repo: "org/app", deployment: { version: "1", environment: "env" } }
-
+        post :create, params: {
+          repo: "org/app",
+          deployment: { version: "1", environment: "env" },
+        }
         assert_response :ok
       end
     end
@@ -62,7 +63,10 @@ class DeploymentsControllerTest < ActionController::TestCase
 
     should "create a deployment record" do
       app = FactoryBot.create(:application, name: "App Name")
-      post :create, params: { repo: "org/app-name", deployment: { version: "v123", environment: "staging", deployed_sha: "v123" } }
+      post :create, params: {
+        repo: "org/app-name",
+        deployment: { version: "v123", environment: "staging", deployed_sha: "v123" },
+      }
 
       deployment = app.reload.deployments.last
       assert_not_nil deployment
@@ -74,24 +78,36 @@ class DeploymentsControllerTest < ActionController::TestCase
     context "application doesn't exist" do
       should "create an application" do
         assert_difference [-> { Deployment.count }, -> { Application.count }], 1 do
-          post :create, params: { repo: "org/new_app", deployment: { version: "release_1", environment: "staging" } }
+          post :create, params: {
+            repo: "org/new_app",
+            deployment: { version: "release_1", environment: "staging" },
+          }
         end
       end
 
       should "generate a friendly name" do
-        post :create, params: { repo: "org/new_app", deployment: { version: "release_1", environment: "staging" } }
+        post :create, params: {
+          repo: "org/new_app",
+          deployment: { version: "release_1", environment: "staging" },
+        }
         app = Application.unscoped.last
         assert_equal "New App", app.name
       end
 
       should "inflect API correctly" do
-        post :create, params: { repo: "org/devops_api", deployment: { version: "release_1", environment: "staging" } }
+        post :create, params: {
+          repo: "org/devops_api",
+          deployment: { version: "release_1", environment: "staging" },
+        }
         app = Application.unscoped.last
         assert_equal "Devops API", app.name
       end
 
       should "generate a friendly name from a name with a dash in it" do
-        post :create, params: { repo: "org/new-app", deployment: { version: "release_1", environment: "staging" } }
+        post :create, params: {
+          repo: "org/new-app",
+          deployment: { version: "release_1", environment: "staging" },
+        }
         app = Application.unscoped.last
         assert_equal "New App", app.name
       end

--- a/test/functional/sites_controller_test.rb
+++ b/test/functional/sites_controller_test.rb
@@ -36,21 +36,17 @@ class SitesControllerTest < ActionController::TestCase
 
     should "update the exiting site settings if they exist" do
       site_settings = FactoryBot.create(:site, status_notes: "Deploys are frozen for now.")
-
       patch :update, params: { site: { status_notes: "Deploy freeze in place." } }
-
       assert_equal "Deploy freeze in place.", site_settings.reload.status_notes
     end
 
     should "redirect to the root on a successful update" do
       patch :update, params: { site: { status_notes: "Deploy freeze in place." } }
-
       assert_redirected_to root_path
     end
 
     should "respond with an unprocessable entity for invalid input" do
       patch :update, params: { site: { status_notes: SecureRandom.alphanumeric(1000) } }
-
       assert_response :unprocessable_entity
     end
   end

--- a/test/helpers/breadcrumb_helper_test.rb
+++ b/test/helpers/breadcrumb_helper_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class BreadcrumbHelperTest < ActionView::TestCase
   should "return a hash of title and url" do
-    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     app_name = SecureRandom.hex
     app = FactoryBot.create(:application, name: app_name)
 

--- a/test/integration/deploy_page_test.rb
+++ b/test/integration/deploy_page_test.rb
@@ -3,7 +3,7 @@ require "integration_test_helper"
 class DeployPageTest < ActionDispatch::IntegrationTest
   setup do
     login_as_stub_user
-    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
   end
 
   test "page handles a single deployment without a previous deployment" do
@@ -16,7 +16,7 @@ class DeployPageTest < ActionDispatch::IntegrationTest
   end
 
   test "page handles a deployment with a previous deployment" do
-    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     application = FactoryBot.create(:application)
 
     commits = [

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -2,7 +2,7 @@ require "integration_test_helper"
 
 class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
   setup do
-    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     @app1 = FactoryBot.create(:application)
     @app2 = FactoryBot.create(:application)
     login_as_stub_user

--- a/test/integration/stats_page_test.rb
+++ b/test/integration/stats_page_test.rb
@@ -7,13 +7,11 @@ class StatsPageTest < ActionDispatch::IntegrationTest
 
   test "page with global stats" do
     visit stats_path
-
     assert page.has_selector?(".gem-c-title__text", text: "Deployments per month")
   end
 
   test "page with stats for an application" do
     stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
-
     application = FactoryBot.create(:application)
 
     visit stats_application_path(application)

--- a/test/integration/stats_page_test.rb
+++ b/test/integration/stats_page_test.rb
@@ -12,7 +12,7 @@ class StatsPageTest < ActionDispatch::IntegrationTest
   end
 
   test "page with stats for an application" do
-    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+    stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
 
     application = FactoryBot.create(:application)
 

--- a/test/integration/unauthenticated_requests_test.rb
+++ b/test/integration/unauthenticated_requests_test.rb
@@ -3,7 +3,6 @@ require "integration_test_helper"
 class UnauthenticatedRequestsTest < ActionDispatch::IntegrationTest
   should "not display the signed in user details when not present" do
     visit "/auth/failure"
-
     assert page.has_no_content?("Signed in as")
   end
 end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -23,7 +23,6 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "be invalid with an empty name" do
       application = Application.new(@atts.merge(name: ""))
-
       assert_not application.valid?
     end
 
@@ -37,13 +36,11 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "default to not be in deploy freeze" do
       application = Application.new(@atts)
-
-      assert_equal false, application.deploy_freeze?
+      assert_not application.deploy_freeze?
     end
 
     should "be invalid with a name that is too long" do
       application = Application.new(@atts.merge(name: ("a" * 256)))
-
       assert_not application.valid?
     end
 

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -8,7 +8,7 @@ class ApplicationTest < ActiveSupport::TestCase
       @atts = {
         name: "Tron-o-matic",
       }
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     context "given valid attributes" do
@@ -94,7 +94,7 @@ class ApplicationTest < ActiveSupport::TestCase
       @atts = {
         name: "Tron-o-matic",
       }
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     context "when the application is not continuously deployed" do
@@ -122,7 +122,7 @@ class ApplicationTest < ActiveSupport::TestCase
   context "live environment" do
     setup do
       @atts = { name: "Tron-o-matic" }
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     should "return production" do
@@ -134,7 +134,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
   describe "#status" do
     before do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       @app = FactoryBot.create(:application, name: SecureRandom.hex)
       Deployment.delete_all
     end
@@ -166,7 +166,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
   describe "#latest_deploys_by_environment" do
     before do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     should "orders main environments" do
@@ -304,7 +304,7 @@ class ApplicationTest < ActiveSupport::TestCase
     before do
       Application.delete_all
       Deployment.delete_all
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     should "return the apps that are out of sync" do

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -5,9 +5,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
   context "creating an application" do
     setup do
-      @atts = {
-        name: "Tron-o-matic",
-      }
+      @atts = { name: "Tron-o-matic" }
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
@@ -45,16 +43,18 @@ class ApplicationTest < ActiveSupport::TestCase
     end
 
     should "be invalid with status_notes that are too long" do
-      application = Application.new(@atts.merge(status_notes: "This app is n#{'o' * 233}t working!"))
-
-      assert_not application.valid?
+      application = Application.new(
+        @atts.merge(status_notes: "This app is n#{'o' * 233}t working!"),
+      )
+      assert_equal false, application.valid?
     end
   end
 
   context "display datetimes" do
     should "use the word today if the release was today" do
-      assert_equal "10:02am today",
-                   human_datetime(Time.zone.now.change(hour: 10, min: 2))
+      assert_equal "10:02am today", human_datetime(
+        Time.zone.now.change(hour: 10, min: 2),
+      )
     end
 
     should "use the word yesterday if the release was yesterday" do
@@ -79,9 +79,7 @@ class ApplicationTest < ActiveSupport::TestCase
 
   context "continuous deployment" do
     setup do
-      @atts = {
-        name: "Tron-o-matic",
-      }
+      @atts = { name: "Tron-o-matic" }
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
@@ -115,7 +113,6 @@ class ApplicationTest < ActiveSupport::TestCase
 
     should "return production" do
       application = Application.new(@atts)
-
       assert_equal "production", application.live_environment
     end
   end
@@ -219,7 +216,10 @@ class ApplicationTest < ActiveSupport::TestCase
 
     describe "#repo_url" do
       should "return the repository url for the apps" do
-        response_body = [{ "app_name" => "account-api", "links" => { "repo_url" => "https://github.com/alphagov/account-api" } }].to_json
+        response_body = [{
+          "app_name" => "account-api",
+          "links" => { "repo_url" => "https://github.com/alphagov/account-api" },
+        }].to_json
         stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
         app = FactoryBot.create(:application, name: "Account API")
@@ -244,7 +244,10 @@ class ApplicationTest < ActiveSupport::TestCase
       end
 
       should "return the shortname for the app" do
-        response_body = [{ "app_name" => "account-api", "shortname" => "account_api" }].to_json
+        response_body = [{
+          "app_name" => "account-api",
+          "shortname" => "account_api",
+        }].to_json
         stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
         app = FactoryBot.create(:application, name: "Account API")
@@ -270,7 +273,10 @@ class ApplicationTest < ActiveSupport::TestCase
     end
 
     should "return the name of the team that owns the app" do
-      response_body = [{ "app_name" => "account-api", "team" => "#tech-content-interactions-on-platform-govuk" }].to_json
+      response_body = [{
+        "app_name" => "account-api",
+        "team" => "#tech-content-interactions-on-platform-govuk",
+      }].to_json
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
       app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")
@@ -279,7 +285,10 @@ class ApplicationTest < ActiveSupport::TestCase
     end
 
     should "return general dev slack channel when it can't find team (because app names don't match)" do
-      response_body = [{ "app_name" => "content-data-admin", "team" => "#govuk-platform-security-reliability-team" }].to_json
+      response_body = [{
+        "app_name" => "content-data-admin",
+        "team" => "#govuk-platform-security-reliability-team",
+      }].to_json
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
       app = FactoryBot.create(:application, name: "Content Data", shortname: "content-data")

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -75,15 +75,6 @@ class ApplicationTest < ActiveSupport::TestCase
         assert_equal "10:02am on 29 Jun", human_datetime(deploy_time)
       end
     end
-
-    should "show a year if the date is old" do
-      assert_equal "2pm on 3 Jul 2010",
-                   human_datetime(Time.zone.now.change(year: 2010, month: 7, day: 3, hour: 14))
-    end
-
-    should "show nothing if the date is missing" do
-      assert_equal "", human_datetime(nil)
-    end
   end
 
   context "continuous deployment" do

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -70,13 +70,8 @@ class DeploymentStatsTest < ActiveSupport::TestCase
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
       FactoryBot.create(:deployment, created_at: "2018-02-01", application: app, environment: "production")
 
-      expected = {
-        "2018-02" => 2,
-      }
-
       stats = DeploymentStats.new(Deployment.where(application_id: app.id)).per_month
-
-      assert_equal(expected, stats)
+      assert_equal({ "2018-02" => 2 }, stats)
     end
   end
 end

--- a/test/unit/deployment_stats_test.rb
+++ b/test/unit/deployment_stats_test.rb
@@ -5,7 +5,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "return correct data" do
       Deployment.delete_all
 
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include deploys from this month (it skews the graph)
@@ -32,7 +32,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "return correct data" do
       Deployment.delete_all
 
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       # Don't include staging deploys
@@ -60,7 +60,7 @@ class DeploymentStatsTest < ActiveSupport::TestCase
     should "scope the results" do
       Deployment.delete_all
 
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       other_app = FactoryBot.create(:application, name: SecureRandom.hex)
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -23,7 +23,7 @@ class DeploymentTest < ActiveSupport::TestCase
     should "return true when SHAs are the same" do
       deployment = FactoryBot.create(:deployment, deployed_sha: "c579613e5f0335ecf409fed881fa7919c150c1af")
 
-      assert_equal true, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+      assert deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
 
     should "return false when SHAs are the different" do
@@ -35,7 +35,7 @@ class DeploymentTest < ActiveSupport::TestCase
     should "return true if deployed_sha is a short SHA" do
       deployment = FactoryBot.create(:deployment, deployed_sha: "c579613")
 
-      assert_equal true, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+      assert deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
 
     should "return false if deployed_sha is nil" do
@@ -59,7 +59,7 @@ class DeploymentTest < ActiveSupport::TestCase
     should "return true if deployment to application's live environment" do
       deployment = FactoryBot.create(:deployment, environment: "production")
 
-      assert_equal true, deployment.to_live_environment?
+      assert deployment.to_live_environment?
     end
 
     should "return false if deployment not to application's live environment" do

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class DeploymentTest < ActiveSupport::TestCase
   describe "#previous_deployment" do
     should "should return the previous version" do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
       app = FactoryBot.create(:application, name: SecureRandom.hex)
 
       previous = FactoryBot.create(:deployment, application: app, environment: "staging")
@@ -17,7 +17,7 @@ class DeploymentTest < ActiveSupport::TestCase
 
   describe "#commit_match?" do
     before do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     should "return true when SHAs are the same" do
@@ -53,7 +53,7 @@ class DeploymentTest < ActiveSupport::TestCase
 
   describe "#to_live_environment?" do
     before do
-      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: "", headers: {})
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
     end
 
     should "return true if deployment to application's live environment" do

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -21,32 +21,31 @@ class DeploymentTest < ActiveSupport::TestCase
     end
 
     should "return true when SHAs are the same" do
-      deployment = FactoryBot.create(:deployment, deployed_sha: "c579613e5f0335ecf409fed881fa7919c150c1af")
-
+      deployment = FactoryBot.create(
+        :deployment, deployed_sha: "c579613e5f0335ecf409fed881fa7919c150c1af"
+      )
       assert deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
 
     should "return false when SHAs are the different" do
-      deployment = FactoryBot.create(:deployment, deployed_sha: "0fa90a3bc5b1c91e9355de3507244e11d8a2d68c")
-
+      deployment = FactoryBot.create(
+        :deployment, deployed_sha: "0fa90a3bc5b1c91e9355de3507244e11d8a2d68c"
+      )
       assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
 
     should "return true if deployed_sha is a short SHA" do
       deployment = FactoryBot.create(:deployment, deployed_sha: "c579613")
-
       assert deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
 
     should "return false if deployed_sha is nil" do
       deployment = FactoryBot.create(:deployment, deployed_sha: nil)
-
       assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
 
     should "return false if deployed_sha too short" do
       deployment = FactoryBot.create(:deployment, deployed_sha: "c5")
-
       assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
   end
@@ -58,13 +57,11 @@ class DeploymentTest < ActiveSupport::TestCase
 
     should "return true if deployment to application's live environment" do
       deployment = FactoryBot.create(:deployment, environment: "production")
-
       assert deployment.to_live_environment?
     end
 
     should "return false if deployment not to application's live environment" do
       deployment = FactoryBot.create(:deployment, environment: "test")
-
       assert_equal false, deployment.to_live_environment?
     end
   end

--- a/test/unit/jobs/post_out_of_sync_deploys_job_test.rb
+++ b/test/unit/jobs/post_out_of_sync_deploys_job_test.rb
@@ -29,16 +29,27 @@ class PostOutOfSyncDeploysJobTest < ActiveJob::TestCase
     expected_message = "Hello :paw_prints:, this is your regular badgering to deploy!\n" \
       "\n" \
       "- <http://release.dev.gov.uk/applications/account-api|Account API> – Production and staging not in sync (<https://github.com/alphagov/account-api/actions/workflows/deploy.yml|Deploy GitHub action>)"
-    assert_enqueued_with job: SlackPosterJob, args: [expected_message, "#tech-content-interactions-on-platform-govuk", { "icon_emoji" => ":badger:" }]
+    assert_enqueued_with job: SlackPosterJob, args: [
+      expected_message,
+      "#tech-content-interactions-on-platform-govuk",
+      { "icon_emoji" => ":badger:" },
+    ]
 
     expected_message = "Hello :paw_prints:, this is your regular badgering to deploy!\n" \
       "\n" \
       "- <http://release.dev.gov.uk/applications/asset-manager|Asset manager> – Undeployed changes in integration (<https://github.com/alphagov/asset-manager/actions/workflows/deploy.yml|Deploy GitHub action>)"
-    assert_enqueued_with job: SlackPosterJob, args: [expected_message, "#govuk-publishing-platform", { "icon_emoji" => ":badger:" }]
+    assert_enqueued_with job: SlackPosterJob, args: [
+      expected_message,
+      "#govuk-publishing-platform",
+      { "icon_emoji" => ":badger:" },
+    ]
   end
 
   should "not enqueue a SlackPosterJob if no teams have out-of-sync apps" do
-    response_body = [{ "app_name" => "account-api", "team" => "#tech-content-interactions-on-platform-govuk" }].to_json
+    response_body = [{
+      "app_name" => "account-api",
+      "team" => "#tech-content-interactions-on-platform-govuk",
+    }].to_json
     stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
     app = FactoryBot.create(:application, name: "Account API", shortname: "account-api")

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -24,8 +24,10 @@ class RepoTest < ActiveSupport::TestCase
 
   describe ".url" do
     should "get the GitHub URL for a repository" do
-      response_body = [{ "app_name" => "account-api",
-                         "links" => { "repo_url" => "https://github.com/alphagov/account-api" } }].to_json
+      response_body = [{
+        "app_name" => "account-api",
+        "links" => { "repo_url" => "https://github.com/alphagov/account-api" },
+      }].to_json
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
       assert_equal "https://github.com/alphagov/account-api", Repo.url(app_name: "Account API")
@@ -34,8 +36,10 @@ class RepoTest < ActiveSupport::TestCase
 
   describe ".shortname" do
     should "get the shortname for a repository" do
-      response_body = [{ "app_name" => "account-api",
-                         "shortname" => "account_api" }].to_json
+      response_body = [{
+        "app_name" => "account-api",
+        "shortname" => "account_api",
+      }].to_json
       stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200, body: response_body)
 
       assert_equal "account_api", Repo.shortname(app_name: "account-api")


### PR DESCRIPTION
- Omit irrelevant args to `WebMock::stub_request()`.
- Simplify some bizarre assertions: `assert_equal true, x` and a strangely convoluted way to compare a couple of fields of objects in a list.
- Delete a couple of test cases that weren't executing any application code 🙃 They didn't seem important enough cases to be worth rewriting.
- Clean up the formatting for hopefully slightly better readability.