### PR TITLE
Add govuk-chat to list of continuously deployed apps

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -16,6 +16,7 @@
 - feedback
 - finder-frontend
 - frontend
+- govuk-chat
 - govuk-dependency-checker
 - government-frontend
 - govuk-account-manager-prototype


### PR DESCRIPTION
This app has been configured with continuous deployment to all
environments now.