### PR TITLE
Add functionality to delete retired apps

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,5 @@
 //= require_tree .
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
+
+//= require rails-ujs

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationsController < ApplicationController
-  before_action :find_application, only: %i[show edit update deploy stats]
+  before_action :find_application, only: %i[show edit update deploy stats destroy]
 
   include ActionView::Helpers::DateHelper
 
@@ -72,6 +72,11 @@ class ApplicationsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @application.destroy!
+    redirect_to applications_path, notice: "Successfully deleted application"
   end
 
 private

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -61,5 +61,17 @@
 
   <%= render "govuk_publishing_components/components/button", {
     text: @application.new_record? ? "Create Application" : "Update application",
+    margin_bottom: 4,
   } %>
+<% end %>
+
+<% unless current_page?(action: 'new') %>
+  <%= form_for @application, method: :delete do |f| %>
+    <%= render "govuk_publishing_components/components/button", {
+        text: "Delete application",
+        destructive: true,
+        data_attributes: { confirm: "Are you sure you wish to delete this application?" },
+        info_text: "You can remove this app if it is retired.",
+      } %>
+  <% end %>
 <% end %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -326,6 +326,24 @@ class ApplicationsControllerTest < ActionController::TestCase
     end
   end
 
+  context "POST destroy" do
+    setup do
+      stub_request(:get, Repo::REPO_JSON_URL).to_return(status: 200)
+      @app = FactoryBot.create(:application)
+    end
+
+    should "delete the application" do
+      assert_difference "Application.count", -1 do
+        post :destroy, params: { id: @app.id }
+      end
+    end
+
+    should "redirect to the index page" do
+      post :destroy, params: { id: @app.id }
+      assert_redirected_to applications_path
+    end
+  end
+
 private
 
   def random_sha


### PR DESCRIPTION
Retired apps are being flagged in the Out of sync release alert and there is no way to remove them in the Release app.

If this PR is merged it will allow an app to have the option of being deleted on the Edit page. There is a popup confirmation dialog when the delete button is pressed to ensure it is not removed by mistake.

Before:
<img width="1137" alt="Screenshot 2024-07-26 at 09 56 34" src="https://github.com/user-attachments/assets/dc68d2bb-3b6e-4d5a-9489-30560b924e2e">

After:
<img width="1142" alt="Screenshot 2024-07-26 at 10 47 09" src="https://github.com/user-attachments/assets/fdfd9dbc-5692-4d12-bef4-2dce9e69168a">

Trello card: https://trello.com/c/cNjbqBcs/3580-allow-to-delete-apps-from-release-3

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
