### PR TITLE
Fix allowed hostname regex

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
-    /release\..*gov.uk$/,
+    /release\..*\.gov.uk$/,
     /^release$/,
   ]
 


### PR DESCRIPTION
This ensures that only .gov.uk. subdomains are used and can't be hijacked by domains suffixed with "gov" e.g. .foogov.uk.

