### PR TITLE
Add migration to remove Jenkins related columns

### DIFF
--- a/db/migrate/20250606151521_remove_jenkins_user_email_from_deployment.rb
+++ b/db/migrate/20250606151521_remove_jenkins_user_email_from_deployment.rb
@@ -1,0 +1,15 @@
+class RemoveJenkinsUserEmailFromDeployment < ActiveRecord::Migration[7.2]
+  def up
+    change_table :deployments, bulk: true do |t|
+      t.remove :jenkins_user_email
+      t.remove :jenkins_user_name
+    end
+  end
+
+  def down
+    change_table :deployments, bulk: true do |t|
+      t.string :jenkins_user_email
+      t.string :jenkins_user_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_27_092810) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_06_151521) do
   create_table "applications", id: :integer, charset: "latin1", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil, null: false
@@ -29,8 +29,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_092810) do
     t.integer "application_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.string "jenkins_user_email"
-    t.string "jenkins_user_name"
     t.string "deployed_sha"
     t.index ["application_id", "environment", "created_at"], name: "index_deployments_on_application_id_etc"
   end
@@ -53,5 +51,4 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_092810) do
     t.boolean "disabled", default: false
     t.string "organisation_content_id", default: ""
   end
-
 end


### PR DESCRIPTION
We are no longer using Jenkins for deployments and this data hasn't been recorded for over 1.5 years.  

The use of those column was removed from the codebase in https://github.com/alphagov/release/commit/5e03be7e8f8c29daf6015a9ca2f7ae5192895d21

Closes https://github.com/alphagov/govuk-infrastructure/issues/1981

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
