### PR TITLE
Add govuk-e2e-tests to  continuously_deployed_apps.yml

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -18,6 +18,7 @@
 - frontend
 - govuk-chat
 - govuk-dependency-checker
+- govuk-e2e-tests
 - government-frontend
 - govuk-account-manager-prototype
 - govuk-attribute-service-prototype


### PR DESCRIPTION
govuk-e2e-tests is a continuously deployed app so add it in to the list of CD apps to avoid confusion.