### PR TITLE
Update k8s_helper to use app.govuk/repository-name

### DIFF
--- a/app/helpers/k8s_helper.rb
+++ b/app/helpers/k8s_helper.rb
@@ -3,7 +3,7 @@ module K8sHelper
     client = Services.k8s(environment: environment)
     client.get_pods(
       namespace: "apps",
-      label_selector: "app.kubernetes.io/name=#{repo_name}",
+      label_selector: "app.govuk/repository-name=#{repo_name}",
       field_selector: { "status.phase": status },
     )
   end

--- a/test/fixtures/k8s/running.json
+++ b/test/fixtures/k8s/running.json
@@ -14,6 +14,7 @@
                 "app.kubernetes.io/instance": "app1",
                 "app.kubernetes.io/managed-by": "Helm",
                 "app.kubernetes.io/name": "app1",
+                "app.govuk/repository-name": "app1",
                 "helm.sh/chart": "app1-0.1.4",
                 "pod-template-hash": "5c4df8b559"
             },


### PR DESCRIPTION
## What

The label selector will use the `app.govuk/repository-name` label as some apps do not have the same cluster app name as repo name. e.g. whitehall repo is whitehall-admin in the cluster

https://github.com/alphagov/govuk-infrastructure/issues/2237