### PR TITLE
Set component to worker for email-alert-service

### DIFF
--- a/app/helpers/k8s_helper.rb
+++ b/app/helpers/k8s_helper.rb
@@ -12,7 +12,11 @@ module K8sHelper
 
   def self.repo_name(repo_name)
     if K8sHelper.k8s_apps.include? repo_name
-      repo_name = K8sHelper.k8s_apps[repo_name]["repo_name"]
+      repo_name = if K8sHelper.k8s_apps[repo_name].include? "repo_name"
+                    K8sHelper.k8s_apps[repo_name]["repo_name"]
+                  else
+                    repo_name
+                  end
     end
     repo_name
   end

--- a/data/k8s_apps.yml
+++ b/data/k8s_apps.yml
@@ -8,3 +8,5 @@ licensify-feed:
 licensify-frontend:
   repo_name: licensify
   namespace: licensify
+email-alert-service:
+  component: worker

--- a/test/helpers/k8s_helper_test.rb
+++ b/test/helpers/k8s_helper_test.rb
@@ -47,6 +47,10 @@ class K8sHelperTest < ActionView::TestCase
     should "returns test-app if not licensify app name" do
       assert_equal "test-app", K8sHelper.repo_name("test-app")
     end
+
+    should "returns email-alert-service if email-alert-service app name" do
+      assert_equal "email-alert-service", K8sHelper.repo_name("email-alert-service")
+    end
   end
 
   context "component" do
@@ -58,6 +62,10 @@ class K8sHelperTest < ActionView::TestCase
       should "returns licensify #{app_name} if not licensify-backend" do
         assert_equal app_name, K8sHelper.component(app_name)
       end
+    end
+
+    should "returns worker if email-alert-service app name" do
+      assert_equal "worker", K8sHelper.component("email-alert-service")
     end
 
     should "returns app if not licensify app name" do


### PR DESCRIPTION
The default is app unless it is a licensify app, but email-alert-service has a component label with worker instead as it doesn't have a web app running.

https://github.com/alphagov/govuk-infrastructure/issues/2237