### PR TITLE
Update running pods to use k8s api data

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -29,7 +29,7 @@ class ApplicationsController < ApplicationController
       end
       begin
         @k8s_available = true
-        @k8s_images = @application.current_image_deployed_by_environment
+        @k8s_data = @application.current_image_deployed_by_environment
       rescue Aws::STS::Errors::ServiceError, Kubeclient::HttpError => e
         @k8s_available = false
         @k8s_error = e.message

--- a/app/helpers/k8s_helper.rb
+++ b/app/helpers/k8s_helper.rb
@@ -47,21 +47,24 @@ module K8sHelper
       images = pod["spec"]["containers"].map { |c| { "image" => c["image"] } }
       {
         "name" => pod["metadata"]["name"],
+        "app_instance" => pod["metadata"]["labels"]["app.kubernetes.io/instance"],
         "images" => images,
         "created_at" => pod["metadata"]["creationTimestamp"],
       }
     end
   end
 
-  def self.k8s_image_tag(environment, repo_name)
+  def self.k8s_data(environment, repo_name)
     pods = running_pods(repo_name: repo_name, environment: environment)
     if pods.empty?
       {
+        "app_instance" => "",
         "image" => "None",
         "created_at" => "",
       }
     else
       {
+        "app_instance" => pods.first["app_instance"],
         "image" => pods.first["images"].first["image"].split(":").last,
         "created_at" => pods.first["created_at"],
       }

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -16,6 +16,6 @@ module UrlHelper
   end
 
   def argo_app_link_to(app_name, environment)
-    link_to(environment, "https://argo.eks.#{environment}.govuk.digital/applications/#{app_name.downcase}", target: "_blank", rel: "noreferrer", class: "govuk-link")
+    link_to(environment, "https://argo.eks.#{environment}.govuk.digital/applications/#{app_name}", target: "_blank", rel: "noreferrer", class: "govuk-link")
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -31,7 +31,7 @@ class Application < ApplicationRecord
   def current_image_deployed_by_environment
     current_env = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment
     @current_image_deployed_by_environment ||= (current_env == "production" ? ENVIRONMENTS_ORDER : (ENVIRONMENTS_ORDER.first 2))
-      .index_with { |environment| K8sHelper.k8s_image_tag(environment, shortname) }
+      .index_with { |environment| K8sHelper.k8s_data(environment, shortname) }
       .compact
   end
 

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -135,14 +135,14 @@
 
   <%= t.body do %>
     <% current_environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
-    <% @k8s_images.each do |environment, image_tag| %>
+    <% @k8s_data.each do |environment, data| %>
       <%= t.row do %>
-        <%= t.header "#{argo_app_link_to(K8sHelper.repo_name(@application.shortname), environment.humanize)}".html_safe()  %>
+        <%= t.header "#{argo_app_link_to(data["app_instance"], environment.humanize)}".html_safe()  %>
 
-        <% if image_tag["image"] == "None" %>
+        <% if data["image"] == "None" %>
           <%= t.cell "No running pods" %>
         <% else %>
-          <%= t.cell "#{image_tag["image"]} at #{human_datetime(image_tag["created_at"])}"  %>
+          <%= t.cell "#{data["image"]} at #{human_datetime(data["created_at"])}"  %>
         <% end %>
       <% end %>
     <% end %>

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -94,6 +94,9 @@ class ApplicationsControllerTest < ActionController::TestCase
         "metadata" => {
           "name" => "Application 1",
           "creationTimestamp" => "2025-01-29T14:27:01Z",
+          "labels" => {
+            "app.kubernetes.io/instance" => "app1",
+          },
         },
       }]
 
@@ -159,8 +162,8 @@ class ApplicationsControllerTest < ActionController::TestCase
 
       should "show Integration and Staging versions of running pods for non-prod environments" do
         get :show, params: { id: @app.id }
-        assert_select "a", { count: 1, text: "Integration" }
-        assert_select "a", { count: 1, text: "Staging" }
+        assert_select "a[href=?]", "https://argo.eks.Integration.govuk.digital/applications/app1", { count: 1, text: "Integration" }
+        assert_select "a[href=?]", "https://argo.eks.Staging.govuk.digital/applications/app1", { count: 1, text: "Staging" }
         assert_select "td", { count: 2, text: "v111 at 2:27pm on 29 Jan" }
       end
     end

--- a/test/helpers/k8s_helper_test.rb
+++ b/test/helpers/k8s_helper_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class K8sHelperTest < ActionView::TestCase
-  context "k8s_image_tag" do
+  context "k8s_data" do
     setup do
       filepath = Rails.root.join("test/fixtures/k8s/running.json")
       mock_resp = JSON.parse(File.read(filepath))
@@ -9,17 +9,17 @@ class K8sHelperTest < ActionView::TestCase
     end
 
     should "can parse response from kubernetes API" do
-      assert_equal "{\"image\":\"v490\",\"created_at\":\"2025-05-14T08:52:29Z\"}", K8sHelper.k8s_image_tag("test", "app1").to_json
+      assert_equal "{\"app_instance\":\"app1\",\"image\":\"v490\",\"created_at\":\"2025-05-14T08:52:29Z\"}", K8sHelper.k8s_data("test", "app1").to_json
     end
   end
 
-  context "k8s_image_tag empty" do
+  context "k8s_data empty" do
     setup do
       K8sHelper.stubs(:pods_by_status).returns([])
     end
 
     should "can parse empty response from kubernetes API" do
-      assert_equal "{\"image\":\"None\",\"created_at\":\"\"}", K8sHelper.k8s_image_tag("test", "app1").to_json
+      assert_equal "{\"app_instance\":\"\",\"image\":\"None\",\"created_at\":\"\"}", K8sHelper.k8s_data("test", "app1").to_json
     end
   end
 

--- a/test/integration/global_status_notes_test.rb
+++ b/test/integration/global_status_notes_test.rb
@@ -18,6 +18,9 @@ class GlobalStatusNotesTest < ActionDispatch::IntegrationTest
       "metadata" => {
         "name" => "Application 1",
         "creationTimestamp" => "2025-01-29T14:27:01Z",
+        "labels" => {
+          "app.kubernetes.io/instance" => "app1",
+        },
       },
     }]
 


### PR DESCRIPTION
Use the `app.kubernetes.io/instance` label to create the link to argo rather than the repo_name as in some cases there is a mis-match. e.g. whitehall should map to whitehall-admin.

Also rename `k8s_image_tag` to `k8s_data`, as it now contains other data and improve the tests to check the link.

https://github.com/alphagov/govuk-infrastructure/issues/2237