### PR TITLE
Update Ruby Base Image to 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG ruby_version=3.3
+ARG ruby_version=3.4
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
-FROM --platform=$TARGETPLATFORM $builder_image AS builder
+FROM $builder_image AS builder
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
@@ -14,7 +14,7 @@ RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 
 
-FROM --platform=$TARGETPLATFORM $base_image
+FROM $base_image
 
 ENV GOVUK_APP_NAME=release
 


### PR DESCRIPTION
## What?
This updates Release's Dockerfile to use 3.4 (this got missed).