### PR TITLE
fix: 🐛 undefined method error on \.sha

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -39,7 +39,7 @@ class Deployment < ApplicationRecord
   end
 
   def commit_match?(sha)
-    commit_sha = commits.first.sha || ""
+    commit_sha = commits.first&.sha || ""
     return false if commit_sha.length < 6
 
     sha.starts_with?(commit_sha)

--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -129,6 +129,19 @@ class DeploymentTest < ActiveSupport::TestCase
       )
       assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
     end
+
+    should "return false if there is no sha field returned" do
+      application = FactoryBot.create(:application, name: SecureRandom.hex)
+      stub_commits(application.repo_path, nil, "c57", "release_70", "release_80")
+
+      FactoryBot.create(
+        :deployment, version: "release_70", application:
+      )
+      deployment = FactoryBot.create(
+        :deployment, version: "release_80", application:
+      )
+      assert_equal false, deployment.commit_match?("c579613e5f0335ecf409fed881fa7919c150c1af")
+    end
   end
 
   describe "#to_live_environment?" do


### PR DESCRIPTION
We are seeing the following:

<img width="699" height="291" alt="image" src="https://github.com/user-attachments/assets/a2d306a2-965d-4eab-9a41-4a39f6d85e0e" />

https://release.publishing.service.gov.uk/applications/govuk-replatform-test-app

This is happening because of [an undefined method error](https://govuk.sentry.io/issues/6844050349/?project=202243&query=is%3Aunresolved&referrer=issue-stream)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
