### PR TITLE
Handle deployments without commits on Deployment page

### DIFF
--- a/app/views/deployments/show.html.erb
+++ b/app/views/deployments/show.html.erb
@@ -27,13 +27,13 @@
   <% if @deployment.previous_deployment %>
     <p><span class="govuk-!-font-weight-bold">Previous version:</span>
       <%= @deployment.previous_version %>
-      <% unless @deployment.previous_version.starts_with?(@deployment.previous_deployment.commits.first.sha) %>
-        (<%= @deployment.previous_deployment.commits.first.sha || "unknown SHA" %>)
+      <% unless @deployment.previous_version.starts_with?(@deployment.previous_deployment.commits.first&.sha) %>
+        (<%= @deployment.previous_deployment.commits.first&.sha || "unknown SHA" %>)
       <% end %>
     <p><span class="govuk-!-font-weight-bold">Deployed version:</span>
         <%= @deployment.version %>
-        <% unless @deployment.version.starts_with?(@deployment.commits.first.sha) %>
-          (<%= @deployment.commits.first.sha || "unknown SHA" %>)
+        <% unless @deployment.version.starts_with?(@deployment.commits.first&.sha) %>
+          (<%= @deployment.commits.first&.sha || "unknown SHA" %>)
         <% end %>
     <p><span class="govuk-!-font-weight-bold">Commits:</span>
       <%= @deployment.commits.count %>


### PR DESCRIPTION
It's possible that commits is equal to an empty array as this is how we handle Octokit::NotFound, causing:
```
   NoMethodError undefined method 'sha' for nil
   (NoMethodError)
```

Replicated in rails console
```
Deployment.find(311409).commits.first.sha
/usr/local/bundle/ruby/3.4.0/gems/irb-1.15.2/lib/irb.rb:406:in 'full_message': undefined method 'sha' for nil (NoMethodError)
```
https://govuk.sentry.io/issues/6896611471/events/f6885b88fd1f41348a52549bf2f30104/

This uses safe navigation operator to handle those edge cases.

Not adding a test as we are not testing views.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
