### PR TITLE
Add content-block-manager to continuously deployed repos

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -5,6 +5,7 @@
 - collections
 - collections-publisher
 - contacts
+- content-block-manager
 - content-data-admin
 - content-data-api
 - content-publisher


### PR DESCRIPTION
It's been configured in https://github.com/alphagov/govuk-helm-charts/pull/3480/files

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
