### PR TITLE
Fix error on Deployment page when commit sha is nil

### DIFF
--- a/app/views/deployments/show.html.erb
+++ b/app/views/deployments/show.html.erb
@@ -27,13 +27,15 @@
   <% if @deployment.previous_deployment %>
     <p><span class="govuk-!-font-weight-bold">Previous version:</span>
       <%= @deployment.previous_version %>
-      <% unless @deployment.previous_version.starts_with?(@deployment.previous_deployment.commits.first&.sha) %>
-        (<%= @deployment.previous_deployment.commits.first&.sha || "unknown SHA" %>)
+      <% previous_sha = @deployment.previous_deployment.commits.first&.sha %>
+      <% unless previous_sha && @deployment.previous_version.start_with?(previous_sha) %>
+        (<%= previous_sha || "unknown SHA" %>)
       <% end %>
     <p><span class="govuk-!-font-weight-bold">Deployed version:</span>
         <%= @deployment.version %>
-        <% unless @deployment.version.starts_with?(@deployment.commits.first&.sha) %>
-          (<%= @deployment.commits.first&.sha || "unknown SHA" %>)
+        <% deployed_sha = @deployment.commits.first&.sha %>
+        <% unless deployed_sha && @deployment.version.starts_with?(deployed_sha) %>
+          (<%= deployed_sha || "unknown SHA" %>)
         <% end %>
     <p><span class="govuk-!-font-weight-bold">Commits:</span>
       <%= @deployment.commits.count %>


### PR DESCRIPTION
We're trying to call `.starts_with?(nil)` which returns:
```
   TypeError
   no implicit conversion of nil into String (TypeError)
```

https://govuk.sentry.io/issues/6899371433/events/d8f06df727e34d6d86f8286390936d5c/

Tested in rails console
```
dep = Deployment.find(311409)
previous_sha = dep.previous_deployment.commits.first&.sha
=> "301e932ef"
unless (previous_sha && dep.previous_version.start_with?(previous_sha))
 previous_sha || "unknown SHA"
end
=> "301e932ef"

deployed_sha = dep.commits.first&.sha
=> nil
unless deployed_sha && dep.previous_version.start_with?(deployed_sha)
  deployed_sha || "unknown SHA"
end
=> "unknown SHA"
```

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
