### PR TITLE
Mark production deployments as change failures [WHIT-2704]

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -105,6 +105,8 @@ private
       :status_notes,
       :task,
       :deploy_freeze,
+      :enable_change_failure_marking,
+      :slack_channel_deployment_notification,
     )
   end
 end

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -46,7 +46,7 @@
     <% end %>
   <% end %>
 
-  <input type="hidden" name="application[deploy_freeze]" value="0" />
+<input type="hidden" name="application[deploy_freeze]" value="0" />
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "application[deploy_freeze]",
     items: [
@@ -58,6 +58,29 @@
       }
     ]
   } %>
+
+  <% if current_user.has_permission?("preview_features") %>
+      <input type="hidden" name="application[enable_change_failure_marking]" value="0" />
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "application[enable_change_failure_marking]",
+        items: [
+          {
+            label: "Enable marking deployments as failures?",
+            value: "1",
+            checked: @application.enable_change_failure_marking?,
+            hint: "Allows marking a deployment as 'failed' for production deployments so that the team can track your failure rate.",
+          }
+        ]
+      } %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Deployment Notification Slack Channel"
+        },
+        name: "application[slack_channel_deployment_notification]",
+        value: @application.slack_channel_deployment_notification,
+        error_message: @application.errors[:slack_channel_deployment_notification].first,
+      } %>
+  <% end %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: @application.new_record? ? "Create Application" : "Update application",

--- a/db/migrate/20260317090512_add_enable_change_failure_marking_to_applications.rb
+++ b/db/migrate/20260317090512_add_enable_change_failure_marking_to_applications.rb
@@ -1,0 +1,6 @@
+class AddEnableChangeFailureMarkingToApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :applications, :enable_change_failure_marking, :boolean, default: false # rubocop:disable Rails/BulkChangeTable
+    add_column :applications, :slack_channel_deployment_notification, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,44 +10,46 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_28_124652) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_17_090512) do
   create_table "applications", id: :integer, charset: "latin1", force: :cascade do |t|
-    t.string "name"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "status_notes"
-    t.string "shortname"
-    t.boolean "deploy_freeze", default: false, null: false
     t.string "default_branch", default: "main", null: false
+    t.boolean "deploy_freeze", default: false, null: false
+    t.boolean "enable_change_failure_marking", default: false
+    t.string "name"
+    t.string "shortname"
+    t.string "slack_channel_deployment_notification"
+    t.string "status_notes"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_applications_on_name", unique: true
     t.index ["shortname"], name: "index_applications_on_shortname"
   end
 
   create_table "deployments", id: :integer, charset: "latin1", force: :cascade do |t|
-    t.string "version"
-    t.string "environment"
     t.integer "application_id"
     t.datetime "created_at", precision: nil, null: false
+    t.string "environment"
     t.datetime "updated_at", precision: nil, null: false
+    t.string "version"
     t.index ["application_id", "environment", "created_at"], name: "index_deployments_on_application_id_etc"
   end
 
   create_table "sites", charset: "utf8mb3", force: :cascade do |t|
-    t.string "status_notes"
     t.datetime "created_at", precision: nil, null: false
+    t.string "status_notes"
     t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "users", id: :integer, charset: "latin1", force: :cascade do |t|
-    t.string "name"
+    t.datetime "created_at", precision: nil, null: false
+    t.boolean "disabled", default: false
     t.string "email"
-    t.string "uid"
+    t.string "name"
+    t.string "organisation_content_id", default: ""
+    t.string "organisation_slug"
     t.text "permissions"
     t.boolean "remotely_signed_out", default: false
-    t.datetime "created_at", precision: nil, null: false
+    t.string "uid"
     t.datetime "updated_at", precision: nil, null: false
-    t.string "organisation_slug"
-    t.boolean "disabled", default: false
-    t.string "organisation_content_id", default: ""
   end
 end

--- a/test/functional/applications_controller_test.rb
+++ b/test/functional/applications_controller_test.rb
@@ -379,6 +379,25 @@ class ApplicationsControllerTest < ActionController::TestCase
       get :edit, params: { id: @app.id }
       assert_select ".govuk-warning-text__text", /Continuous deployment between each environment has to be disabled or enabled * via GitHub action/
     end
+
+    context "user has preview_features permissions" do
+      setup do
+        @stub_user.permissions.push("preview_features")
+        @app.slack_channel_deployment_notification = "monkey notifications"
+        @app.save!
+      end
+
+      teardown do
+        @stub_user.permissions.delete("preview_features")
+      end
+
+      should "show the form" do
+        get :edit, params: { id: @app.id }
+        assert_select "form.edit_application input[name='application[name]'][value='#{@app.name}']"
+        assert_select "form.edit_application input[name='application[enable_change_failure_marking]'][value='1']"
+        assert_select "form.edit_application input[name='application[slack_channel_deployment_notification]'][value='#{@app.slack_channel_deployment_notification}']"
+      end
+    end
   end
 
   context "PUT update" do
@@ -389,10 +408,12 @@ class ApplicationsControllerTest < ActionController::TestCase
 
     context "valid request" do
       should "update the application" do
-        put :update, params: { id: @app.id, application: { name: "new name", deploy_freeze: true } }
+        put :update, params: { id: @app.id, application: { name: "new name", deploy_freeze: true, enable_change_failure_marking: true, slack_channel_deployment_notification: true } }
         @app.reload
         assert_equal "new name", @app.name
         assert @app.deploy_freeze?
+        assert @app.enable_change_failure_marking?
+        assert @app.slack_channel_deployment_notification?
       end
 
       should "redirect to the application" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,12 +22,12 @@ class ActiveSupport::TestCase
     graphql_responses.clear
   end
 
-  def stub_user
-    @stub_user ||= FactoryBot.create(:user, name: "Stub User")
+  def stub_user(permissions = [])
+    @stub_user ||= FactoryBot.create(:user, name: "Stub User", permissions: permissions.push("signin"))
   end
 
-  def login_as_stub_user
-    stub_warden_as stub_user
+  def login_as_stub_user(permissions = [])
+    stub_warden_as stub_user(permissions)
   end
 
   def stub_warden_as(user)

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -37,6 +37,11 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_not application.deploy_freeze?
     end
 
+    should "default to not have enable change failure marking checked" do
+      application = Application.new(@atts)
+      assert_not application.enable_change_failure_marking?
+    end
+
     should "be invalid with a name that is too long" do
       application = Application.new(@atts.merge(name: ("a" * 256)))
       assert_not application.valid?


### PR DESCRIPTION
As a release app user, I should be able to enable marking production deployments as change failures and set a Slack channel for deployment messages in the application settings.

Jira: https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2704
