### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,37 @@
+---
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: bundler
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
 
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
+# Ruby needs to be upgraded manually in multiple places, so cannot
+# be upgraded by Dependabot. That effectively makes the below
+# config redundant, as ruby is the only updatable thing in the
+# Dockerfile, although this may change in the future. We hope this
+# config will save a dev from trying to upgrade ruby via Dependabot.
+- package-ecosystem: docker
+  ignore:
+  - dependency-name: ruby
+  directory: /
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 10
 
-  # Ruby needs to be upgraded manually in multiple places, so cannot
-  # be upgraded by Dependabot. That effectively makes the below
-  # config redundant, as ruby is the only updatable thing in the
-  # Dockerfile, although this may change in the future. We hope this
-  # config will save a dev from trying to upgrade ruby via Dependabot.
-  - package-ecosystem: docker
-    ignore:
-      - dependency-name: ruby
-    directory: /
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+...


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
