### PR TITLE
BAU - Fix `deployment_test` wrong integer size

### DIFF
--- a/test/unit/deployment_test.rb
+++ b/test/unit/deployment_test.rb
@@ -150,12 +150,12 @@ class DeploymentTest < ActiveSupport::TestCase
     end
 
     should "return true if deployment to application's live environment" do
-      deployment = FactoryBot.create(:deployment, environment: "production", id: SecureRandom.hex(6))
+      deployment = FactoryBot.create(:deployment, environment: "production", id: SecureRandom.hex(4))
       assert deployment.to_live_environment?
     end
 
     should "return false if deployment not to application's live environment" do
-      deployment = FactoryBot.create(:deployment, environment: "test", id: SecureRandom.hex(6))
+      deployment = FactoryBot.create(:deployment, environment: "test", id: SecureRandom.hex(4))
       assert_equal false, deployment.to_live_environment?
     end
   end


### PR DESCRIPTION
Description:
- https://github.com/alphagov/release/blob/main/test/unit/deployment_test.rb#L153 is failing in https://github.com/alphagov/release/actions/runs/24515940540/job/71659808805#step:8:112 because
```
RuntimeError: Neutered Exception ActiveModel::RangeError: 178237509603 is out of range for ActiveModel::Type::Integer with limit 4 bytes
```
- This is because `SecureRandom.hex(6))` is generating 6 bytes when the `id` column in MySQL has a limit of 4 bytes. So set this to `hex(4)` to stop the test from failing
