### PR TITLE
Switch to ARM-only build (to test it)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-push-arm-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:


### PR DESCRIPTION
## What?
This switches the GOV.UK Release app to the ARM-only build workflow so we can test that it works as expected.

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/2938