### PR TITLE
Fix the "rails-ujs already loaded" error.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,4 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require release
-
 //= require rails-ujs

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -6,6 +6,10 @@
 // on browsers that don't support ES6, this script
 // should be included in a `type="module"` script tag
 // which will ensure they are never loaded.
+//
+// This will probably not be needed with modern
+// browsers that support newer JS features.
 
+//= require govuk_publishing_components/initialise-vars
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/tabs

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,5 @@
 <% content_for :head do %>
   <%= csrf_meta_tag %>
-  <%= javascript_include_tag "application" %>
   <%= javascript_include_tag "admin" %>
 <% end %>
 


### PR DESCRIPTION
## What?
This fixes the "rails-ujs already loaded" error that is being presented by the Browser Console. 

## Why?
We were getting this error, following the previous fixes:

```
Uncaught Error: rails-ujs has already been loaded!
```

**Reason:** `application.js` was being loaded twice.

I have also added "initialise-vars" to the es6-components loader to prevent an intermittent issue I spotted while there were still stale assets being used by the browser - specifically, because the browser was failing to handle:
```
window.GOVUK.Modules.GovukButton = window.GOVUKFrontend.Button,
```
...as "Modules" wasn't defined.

### How?

 - `app/views/layouts/application.html.erb` had explicitly included `application.js`
 - `govuk_publishing_components/components/layout_for_admin` also included `application.js` automatically at end of `<body>`