### PR TITLE
Mark fact-check-manager as being continuously deployed

### DIFF
--- a/data/continuously_deployed_apps.yml
+++ b/data/continuously_deployed_apps.yml
@@ -14,6 +14,7 @@
 - email-alert-api
 - email-alert-frontend
 - email-alert-service
+- fact-check-manager
 - feedback
 - finder-frontend
 - frontend


### PR DESCRIPTION
### Changes
Remove the "Manually deployed label" from fact-check-manager

This app has now been configured to be continuously deployed in helm-charts:
https://github.com/alphagov/govuk-helm-charts/tree/main/charts/app-config/image-tags